### PR TITLE
Require SESSION_SECRET

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Sistema POS
+
+This project contains a point-of-sale application with a React frontend and an Express backend.
+
+## Environment variables
+
+The server requires a `SESSION_SECRET` environment variable for managing user sessions. The
+application will throw an error during startup if this variable is not defined.
+

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -31,8 +31,13 @@ export async function comparePasswords(supplied: string, stored: string) {
 }
 
 export function setupAuth(app: Express) {
+  const { SESSION_SECRET } = process.env;
+  if (!SESSION_SECRET) {
+    throw new Error("SESSION_SECRET environment variable is required");
+  }
+
   const sessionSettings: session.SessionOptions = {
-    secret: process.env.SESSION_SECRET || "punto-pastelero-secret",
+    secret: SESSION_SECRET,
     resave: true,
     saveUninitialized: true,
     store: storage.sessionStore,


### PR DESCRIPTION
## Summary
- enforce providing SESSION_SECRET in `setupAuth`
- add README with env var requirement

## Testing
- `npm run check` *(fails: Unexpected keyword or identifier in client/src/services/api.ts)*

------
https://chatgpt.com/codex/tasks/task_e_685bf44c90f48331aa1cb438f50fcd5b