### PR TITLE
Improve typings for bank account functions

### DIFF
--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -1,4 +1,4 @@
-async createSale(saleData: any) {
+export async function createSale(saleData: any) {
   try {
     // Verificar si la sesión está activa antes de hacer la petición
     const response = await fetch(`${this.baseUrl}/api/sales`, {

--- a/server/api/bank-accounts.ts
+++ b/server/api/bank-accounts.ts
@@ -10,6 +10,8 @@ const bankAccountSchema = z.object({
   isActive: z.boolean().default(true)
 });
 
+export type BankAccountData = z.infer<typeof bankAccountSchema>;
+
 export async function getBankAccounts() {
   try {
     console.log("Obteniendo todas las cuentas bancarias...");
@@ -22,7 +24,7 @@ export async function getBankAccounts() {
   }
 }
 
-export async function createBankAccount(data: any) {
+export async function createBankAccount(data: BankAccountData) {
   try {
     console.log("Intentando crear nueva cuenta bancaria con datos:", data);
     
@@ -43,7 +45,7 @@ export async function createBankAccount(data: any) {
   }
 }
 
-export async function updateBankAccount(id: number, data: any) {
+export async function updateBankAccount(id: number, data: BankAccountData) {
   try {
     console.log(`Intentando actualizar cuenta bancaria con ID ${id} con datos:`, data);
     

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -65,7 +65,7 @@ export interface IStorage {
   // Account Transactions
   getAccountTransaction(id: number): Promise<AccountTransaction | undefined>;
   getAccountTransactions(accountId: number): Promise<AccountTransaction[]>;
-  createAccountTransaction(transaction: any): Promise<AccountTransaction>;
+  createAccountTransaction(transaction: InsertAccountTransaction): Promise<AccountTransaction>;
   
   // Sales
   getSale(id: number): Promise<Sale | undefined>;
@@ -618,7 +618,7 @@ export class MemStorage implements IStorage {
       });
   }
   
-  async createAccountTransaction(insertTransaction: any): Promise<AccountTransaction> {
+  async createAccountTransaction(insertTransaction: InsertAccountTransaction): Promise<AccountTransaction> {
     const id = this.accountTransactionIdCounter++;
     const transaction: AccountTransaction = { 
       ...insertTransaction, 


### PR DESCRIPTION
## Summary
- infer `BankAccountData` from `bankAccountSchema`
- use this type in `createBankAccount` and `updateBankAccount`
- type account transaction creation with `InsertAccountTransaction`
- export `createSale` in the API service

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685bf46fa4a083318a29e6c63365da09