### PR TITLE
Add unified document selector

### DIFF
--- a/client/src/components/invoices/InvoiceDetail.tsx
+++ b/client/src/components/invoices/InvoiceDetail.tsx
@@ -23,11 +23,18 @@ export const InvoiceContent = forwardRef<HTMLDivElement, InvoiceDetailProps>(
 
     const getDocumentTypeName = (type: string) => {
       switch (type) {
-        case 'remito': return 'Remito';
-        case 'factura_a': return 'Factura A';
-        case 'factura_b': return 'Factura B';
-        case 'factura_c': return 'Factura C';
-        default: return type;
+        case 'remito':
+          return 'Remito';
+        case 'remito_x':
+          return 'Remito X';
+        case 'factura_a':
+          return 'Factura A';
+        case 'factura_b':
+          return 'Factura B';
+        case 'factura_c':
+          return 'Factura C';
+        default:
+          return type;
       }
     };
 

--- a/client/src/components/printing/InvoicePDF.tsx
+++ b/client/src/components/printing/InvoicePDF.tsx
@@ -168,11 +168,18 @@ export function InvoicePDF({ invoiceRef, documentId, documentType }: InvoicePDFP
 
   const getDocumentName = (type: string) => {
     switch (type) {
-      case 'remito': return 'Remito';
-      case 'factura_a': return 'Factura_A';
-      case 'factura_b': return 'Factura_B';
-      case 'factura_c': return 'Factura_C';
-      default: return 'Documento';
+      case 'remito':
+        return 'Remito';
+      case 'remito_x':
+        return 'Remito_X';
+      case 'factura_a':
+        return 'Factura_A';
+      case 'factura_b':
+        return 'Factura_B';
+      case 'factura_c':
+        return 'Factura_C';
+      default:
+        return 'Documento';
     }
   };
 

--- a/client/src/pages/pos.tsx
+++ b/client/src/pages/pos.tsx
@@ -73,7 +73,7 @@ const POSPage = () => {
   });
   const [checkoutDialogOpen, setCheckoutDialogOpen] = useState(false);
   const [barcodeInput, setBarcodeInput] = useState("");
-  const [documentType, setDocumentType] = useState<"factura" | "remito" | "pedido" | "presupuesto">("remito");
+  const [documentType, setDocumentType] = useState<"factura_c" | "remito_x" | "pedido" | "presupuesto">("remito_x");
   const [observations, setObservations] = useState("");
   const [printTicket, setPrintTicket] = useState(true);
   const [sendEmail, setSendEmail] = useState(false);
@@ -98,7 +98,7 @@ const POSPage = () => {
   const [isGeneratingPDF, setIsGeneratingPDF] = useState(false);
   const [saleId, setSaleId] = useState<number | null>(null);
   const [showInvoice, setShowInvoice] = useState(false);
-  const [invoiceType, setInvoiceType] = useState<"remito" | "factura_c">("remito");
+  const [invoiceType, setInvoiceType] = useState<"remito_x" | "factura_c">("remito_x");
   const [showThermalTicket, setShowThermalTicket] = useState(false);
   const [showInvoicePDF, setShowInvoicePDF] = useState(false);
   const [printOptions, setPrintOptions] = useState({
@@ -219,7 +219,7 @@ const POSPage = () => {
       });
 
       // Mostrar el diálogo de recibo solo para ventas
-      if (data.documentType === "factura" || data.documentType === "remito") {
+      if (data.documentType === "factura_c" || data.documentType === "remito_x") {
         setShowReceiptDialog(true);
       }
       
@@ -609,7 +609,7 @@ const POSPage = () => {
       });
 
       // Mostrar opciones de impresión solo para facturas y remitos
-      if (documentType === "factura" || documentType === "remito") {
+      if (documentType === "factura_c" || documentType === "remito_x") {
         setShowThermalTicket(true);
       }
     } catch (error) {
@@ -678,7 +678,7 @@ const POSPage = () => {
   console.log('showReceiptDialog:', showReceiptDialog);
   
   const handleDocumentTypeChange = (value: string) => {
-    const newValue = value as "factura" | "remito" | "pedido" | "presupuesto";
+    const newValue = value as "factura_c" | "remito_x" | "pedido" | "presupuesto";
     setDocumentType(newValue);
     // Si es presupuesto o pedido, no permitir finalizar la venta
     if (newValue === "presupuesto" || newValue === "pedido") {
@@ -708,9 +708,9 @@ const POSPage = () => {
                       <SelectValue placeholder="Seleccionar tipo de comprobante" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="factura">Factura</SelectItem>
-                      <SelectItem value="remito">Remito</SelectItem>
-                      <SelectItem value="pedido">Pedido</SelectItem>
+                      <SelectItem value="factura_c">Factura C</SelectItem>
+                      <SelectItem value="remito_x">Remito X</SelectItem>
+                      <SelectItem value="pedido">Nota de Pedido</SelectItem>
                       <SelectItem value="presupuesto">Presupuesto</SelectItem>
                     </SelectContent>
                   </Select>
@@ -1042,8 +1042,8 @@ const POSPage = () => {
                     >
                       {documentType === "presupuesto" ? "Guardar Presupuesto" :
                        documentType === "pedido" ? "Guardar Pedido" :
-                       documentType === "factura" ? "Finalizar Venta con Factura" :
-                       "Finalizar Venta con Remito"}
+                       documentType === "factura_c" ? "Finalizar Venta con Factura C" :
+                       "Finalizar Venta con Remito X"}
                     </Button>
                   </div>
                 </div>
@@ -1060,14 +1060,14 @@ const POSPage = () => {
             <DialogTitle className="text-xl">
               {documentType === "presupuesto" ? "Guardar Presupuesto" :
                documentType === "pedido" ? "Guardar Pedido" :
-               documentType === "factura" ? "Finalizar Venta con Factura" :
-               "Finalizar Venta con Remito"}
+               documentType === "factura_c" ? "Finalizar Venta con Factura C" :
+               "Finalizar Venta con Remito X"}
             </DialogTitle>
             <DialogHeader className="text-muted-foreground text-sm mt-1">
               {documentType === "presupuesto" ? "Complete los datos para guardar el presupuesto" :
                documentType === "pedido" ? "Complete los datos para guardar el pedido" :
-               documentType === "factura" ? "Complete los datos para finalizar la venta y generar la factura" :
-               "Complete los datos para finalizar la venta y generar el remito"}
+               documentType === "factura_c" ? "Complete los datos para finalizar la venta y generar la factura C" :
+               "Complete los datos para finalizar la venta y generar el remito X"}
             </DialogHeader>
           </DialogHeader>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 py-4">
@@ -1101,9 +1101,9 @@ const POSPage = () => {
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="factura">Factura</SelectItem>
-                      <SelectItem value="remito">Remito</SelectItem>
-                      <SelectItem value="pedido">Pedido</SelectItem>
+                      <SelectItem value="factura_c">Factura C</SelectItem>
+                      <SelectItem value="remito_x">Remito X</SelectItem>
+                      <SelectItem value="pedido">Nota de Pedido</SelectItem>
                       <SelectItem value="presupuesto">Presupuesto</SelectItem>
                     </SelectContent>
                   </Select>
@@ -1492,8 +1492,8 @@ const POSPage = () => {
                   </>
                 ) : documentType === "presupuesto" ? "Guardar Presupuesto" :
                    documentType === "pedido" ? "Guardar Pedido" :
-                   documentType === "factura" ? "Finalizar Venta con Factura" :
-                   "Finalizar Venta con Remito"
+                   documentType === "factura_c" ? "Finalizar Venta con Factura C" :
+                   "Finalizar Venta con Remito X"
                 }
               </Button>
             </div>
@@ -1532,13 +1532,13 @@ const POSPage = () => {
         <DialogContent className="max-w-4xl max-h-[85vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle className="text-xl">
-              {completedSale?.documentType === "factura" ? "Factura" :
-               completedSale?.documentType === "remito" ? "Remito" :
+              {completedSale?.documentType === "factura_c" ? "Factura C" :
+               completedSale?.documentType === "remito_x" ? "Remito X" :
                "Comprobante"}
             </DialogTitle>
             <DialogDescription>
-              {completedSale?.documentType === "factura" ? "Factura generada exitosamente" :
-               completedSale?.documentType === "remito" ? "Remito generado exitosamente" :
+              {completedSale?.documentType === "factura_c" ? "Factura C generada exitosamente" :
+               completedSale?.documentType === "remito_x" ? "Remito X generado exitosamente" :
                "Documento generado exitosamente"}
             </DialogDescription>
           </DialogHeader>
@@ -1624,7 +1624,7 @@ const POSPage = () => {
       </Dialog>
 
       {/* Modal de ticket térmico - Solo para ventas */}
-      {completedSale && completedSale.items && (completedSale.documentType === "factura" || completedSale.documentType === "remito") && (
+      {completedSale && completedSale.items && (completedSale.documentType === "factura_c" || completedSale.documentType === "remito_x") && (
         <ThermalTicket
           sale={completedSale}
           saleItems={completedSale.items}

--- a/client/src/services/pdfService.ts
+++ b/client/src/services/pdfService.ts
@@ -46,9 +46,14 @@ export const PDFService = {
       // Tipo de documento y número
       pdf.setFont('helvetica', 'bold');
       pdf.setFontSize(12);
-      const docType = sale.documentType.startsWith('factura') 
-          ? sale.documentType.replace('_', ' ').toUpperCase() 
-          : 'REMITO';
+      let docType = '';
+      if (sale.documentType.startsWith('factura')) {
+        docType = sale.documentType.replace('_', ' ').toUpperCase();
+      } else if (sale.documentType === 'remito_x') {
+        docType = 'REMITO X';
+      } else {
+        docType = 'REMITO';
+      }
       pdf.text(docType, pageWidth - margin - pdf.getTextWidth(docType), 25);
       
       pdf.setFont('helvetica', 'normal');

--- a/client/src/services/printService.ts
+++ b/client/src/services/printService.ts
@@ -215,11 +215,18 @@ export const PrintService = {
   // Función para obtener el nombre amigable del tipo de documento
   getDocumentTypeName(type: string): string {
     switch (type) {
-      case 'remito': return 'Remito';
-      case 'factura_a': return 'Factura A';
-      case 'factura_b': return 'Factura B';
-      case 'factura_c': return 'Factura C';
-      default: return type;
+      case 'remito':
+        return 'Remito';
+      case 'remito_x':
+        return 'Remito X';
+      case 'factura_a':
+        return 'Factura A';
+      case 'factura_b':
+        return 'Factura B';
+      case 'factura_c':
+        return 'Factura C';
+      default:
+        return type;
     }
   }
 };


### PR DESCRIPTION
## Summary
- allow choosing `Factura C`, `Remito X`, `Nota de Pedido` or `Presupuesto` on the POS page
- show proper labels in dialogs and receipts
- support `remito_x` document type in printing helpers
- update PDF service to label `remito_x` correctly

## Testing
- `npm run check` *(fails: client/src/services/api.ts(1,1): error TS1434: Unexpected keyword or identifier)*

------
https://chatgpt.com/codex/tasks/task_e_685bf57c56f48331a80ac76939329ce2