### PR TITLE
Add logistics stats endpoint

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1565,6 +1565,30 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // ======= ENDPOINTS DE LOGÍSTICA ======= //
 
+  // Endpoint de estadísticas generales para logística
+  app.get("/api/logistics/stats", async (_req, res) => {
+    try {
+      const deliveries = await storage.getAllDeliveries();
+      const vehicles = await storage.getAllVehicles();
+      const routes = await storage.getAllDeliveryRoutes();
+      const assignments = await storage.getAllRouteAssignments();
+
+      const stats = {
+        pendingDeliveries: deliveries.filter(d => d.status === "pending").length,
+        inTransitDeliveries: deliveries.filter(d => d.status === "assigned" || d.status === "in_transit").length,
+        completedDeliveries: deliveries.filter(d => d.status === "delivered").length,
+        totalVehicles: vehicles.length,
+        activeVehicles: vehicles.filter(v => v.active).length,
+        totalRoutes: routes.length,
+        pendingAssignments: assignments.filter(a => a.status === "pending").length,
+      };
+
+      res.json(stats);
+    } catch (error) {
+      res.status(500).json({ message: "Error al obtener estadísticas", error: (error as Error).message });
+    }
+  });
+
   // Vehículos
   app.get("/api/vehicles", async (req, res) => {
     try {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -141,6 +141,7 @@ export interface IStorage {
   
   // Route Assignments
   getRouteAssignment(id: number): Promise<RouteAssignment | undefined>;
+  getAllRouteAssignments(): Promise<RouteAssignment[]>;
   getRouteAssignmentsByDate(date: Date): Promise<RouteAssignment[]>;
   getRouteAssignmentsByDriver(driverId: number): Promise<RouteAssignment[]>;
   createRouteAssignment(assignment: InsertRouteAssignment): Promise<RouteAssignment>;
@@ -1368,6 +1369,10 @@ export class MemStorage implements IStorage {
   // Route Assignments
   async getRouteAssignment(id: number): Promise<RouteAssignment | undefined> {
     return this.routeAssignments.get(id);
+  }
+
+  async getAllRouteAssignments(): Promise<RouteAssignment[]> {
+    return Array.from(this.routeAssignments.values());
   }
   
   async getRouteAssignmentsByDate(date: Date): Promise<RouteAssignment[]> {


### PR DESCRIPTION
## Summary
- implement `/api/logistics/stats` route to provide delivery statistics
- expose new `getAllRouteAssignments` storage method used by the route

## Testing
- `npm run check` *(fails: Unexpected keyword or identifier in client/src/services/api.ts)*

------
https://chatgpt.com/codex/tasks/task_e_685c001b1ac08331987093eeaaaceac9