### PR TITLE
Añadir costo por bulto

### DIFF
--- a/client/src/components/products/PricingTab.tsx
+++ b/client/src/components/products/PricingTab.tsx
@@ -151,6 +151,28 @@ export function PricingTab({ form, recalculatePrice, recalculateWholesalePrice }
                 </FormItem>
               )}
             />
+
+            <FormField
+              control={form.control}
+              name="unitsPerPack"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Unidades por Bulto</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      step="1"
+                      min="1"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Cantidad de unidades que trae el bulto
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
             
             <FormField
               control={form.control}

--- a/client/src/pages/products-page.tsx
+++ b/client/src/pages/products-page.tsx
@@ -77,6 +77,9 @@ const productFormSchema = insertProductSchema.extend({
   profit: z.coerce.number().min(0).default(55),
   wholesaleProfit: z.coerce.number().min(0).default(35),
   supplierDiscount: z.coerce.number().min(0).max(100).optional().default(0),
+
+  // Cantidad de unidades por bulto
+  unitsPerPack: z.coerce.number().min(1).default(1),
   
   // For bulk products, we need to manage conversion rates
   // This will be transformed before submission
@@ -309,6 +312,7 @@ export default function ProductsPage() {
       isComposite: false,
       active: true,    // Activo por defecto
       webVisible: false, // No visible en web por defecto
+      unitsPerPack: 1,
       category: "",
       categoryIds: [],
       imageUrl: "",
@@ -501,6 +505,7 @@ export default function ProductsPage() {
       profit: product.profit || 55,
       wholesaleProfit: product.wholesaleProfit || 35,
       supplierDiscount: product.supplierDiscount || 0,
+      unitsPerPack: product.unitsPerPack ? parseFloat(product.unitsPerPack) : 1,
       supplierId: product.supplierId,
       supplierCode: product.supplierCode || "",
       category: product.category || "",
@@ -555,6 +560,7 @@ export default function ProductsPage() {
       active: true,    // Activo por defecto
       webVisible: false, // No visible en web por defecto
       isDiscontinued: false, // No discontinuado por defecto
+      unitsPerPack: 1,
       category: "",
       categoryIds: [],
       imageUrl: "",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4439,20 +4439,24 @@ export async function registerRoutes(app: Express): Promise<Server> {
           const shippingRate = parseFloat(product.shipping?.toString() || "0");
           const profitRate = parseFloat(product.profit?.toString() || "55");
           const wholesaleProfitRate = parseFloat(product.wholesaleProfit?.toString() || "35");
-          
+
+          // Si el producto se compra por bulto, calcular el costo unitario
+          const unitsPerPack = parseFloat(product.unitsPerPack?.toString() || "1");
+          const unitCost = unitsPerPack > 0 ? newCost / unitsPerPack : newCost;
+
           // Preparar datos de actualización
-          const updateData: any = { 
-            cost: newCost.toString(),
+          const updateData: any = {
+            cost: unitCost.toString(),
             lastUpdated: new Date()
           };
-          
+
           // Solo actualizar precios si no se debe mantener los actuales
           if (!keepCurrentPrices) {
-            // Calcular nuevo precio minorista
-            const costWithIva = newCost * (1 + (ivaRate / 100));
+            // Calcular nuevo precio minorista partiendo del costo unitario
+            const costWithIva = unitCost * (1 + (ivaRate / 100));
             const costWithShipping = costWithIva * (1 + (shippingRate / 100));
             const newPrice = Math.round(costWithShipping * (1 + (profitRate / 100)) * 100) / 100;
-            
+
             // Calcular nuevo precio mayorista
             const newWholesalePrice = Math.round(costWithShipping * (1 + (wholesaleProfitRate / 100)) * 100) / 100;
             

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -501,6 +501,7 @@ export class MemStorage implements IStorage {
       components: insertProduct.components || null,
       conversionRates: insertProduct.conversionRates || null,
       isBulk: insertProduct.isBulk ?? false,
+      unitsPerPack: insertProduct.unitsPerPack || "1",
       supplierId: insertProduct.supplierId || null,
       supplierCode: insertProduct.supplierCode || null,
       category: insertProduct.category || null,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -92,6 +92,8 @@ export const products = pgTable("products", {
   supplierCode: text("supplier_code"),
   isRefrigerated: boolean("is_refrigerated").default(false),
   isBulk: boolean("is_bulk").default(false),
+  // Cantidad de unidades por bulto para cálculos de costo
+  unitsPerPack: numeric("units_per_pack", { precision: 10, scale: 2 }).default("1"),
   // Indicar si es un producto compuesto (combo)
   isComposite: boolean("is_composite").default(false),
   // Indicar si el producto está activo (disponible para vender)
@@ -146,6 +148,7 @@ export const insertProductSchema = createInsertSchema(products).pick({
   shipping: true,
   profit: true,
   wholesaleProfit: true,
+  unitsPerPack: true,
   components: true,
   currency: true,
 });


### PR DESCRIPTION
## Resumen
- agregar `unitsPerPack` en la tabla de productos y en el schema de inserción
- recalcular el costo unitario en `/api/products/update-cost-by-file`
- incluir `unitsPerPack` en el formulario y en la UI de precios

## Testing
- `npm run check` *(falla: falta dependencias)*

------
https://chatgpt.com/codex/tasks/task_e_685e994ac44c83319924dda4258b1284