### PR TITLE
Fix budget feature

### DIFF
--- a/client/src/components/budgets/budget-form-dialog.tsx
+++ b/client/src/components/budgets/budget-form-dialog.tsx
@@ -141,12 +141,12 @@ export function BudgetFormDialog({ open, onOpenChange }: BudgetFormDialogProps) 
     try {
       const budgetData = {
         customerId: selectedCustomerId,
-        items: cart.map(item => ({
+        items: cart.map((item) => ({
           productId: item.productId,
           quantity: item.quantity,
           unit: item.unit,
           price: item.price,
-          total: item.total
+          total: item.total,
         })),
         subtotal: cartSubtotal,
         discount: discountAmount,
@@ -155,11 +155,22 @@ export function BudgetFormDialog({ open, onOpenChange }: BudgetFormDialogProps) 
         paymentMethod,
         observations,
         validityDays,
-        status: "pending"
+        status: "pending",
       };
 
-      // TODO: Implement budget creation API call
-      // await apiRequest("POST", "/api/budgets", budgetData);
+      await apiRequest("POST", "/api/quotations", {
+        clientId: budgetData.customerId,
+        dateValidUntil: new Date(
+          Date.now() + budgetData.validityDays * 24 * 60 * 60 * 1000
+        ).toISOString(),
+        notes: budgetData.observations,
+        items: budgetData.items.map((i) => ({
+          productId: i.productId,
+          quantity: i.quantity,
+          unitPrice: i.price,
+          subtotal: i.total,
+        })),
+      });
 
       toast({
         title: "Presupuesto creado",

--- a/client/src/components/budgets/budgets-table.tsx
+++ b/client/src/components/budgets/budgets-table.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link } from "wouter";
 import { MoreHorizontal, FileText } from "lucide-react";
 import {
@@ -18,33 +18,24 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { formatCurrency } from "@/lib/utils";
-
-interface Budget {
-  id: string;
-  number: string;
-  customer: {
-    name: string;
-  };
-  total: number;
-  status: "pending" | "approved" | "rejected";
-  createdAt: string;
-}
-
-const budgets: Budget[] = [
-  {
-    id: "1",
-    number: "P-0001",
-    customer: {
-      name: "Cliente Ejemplo",
-    },
-    total: 15000,
-    status: "pending",
-    createdAt: "2024-04-30T12:00:00Z",
-  },
-];
+import { quotationService } from "@/services/quotationService";
+import { Quotation } from "@/types/quotation";
 
 export function BudgetsTable() {
-  const [selectedBudget, setSelectedBudget] = useState<Budget | null>(null);
+  const [budgets, setBudgets] = useState<Quotation[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await quotationService.getQuotations();
+        setBudgets(data);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
 
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString("es-AR", {
@@ -54,12 +45,16 @@ export function BudgetsTable() {
     });
   };
 
+  if (loading) {
+    return <div className="p-4">Cargando...</div>;
+  }
+
   return (
     <div className="rounded-md border">
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead>Número</TableHead>
+            <TableHead>ID</TableHead>
             <TableHead>Cliente</TableHead>
             <TableHead>Total</TableHead>
             <TableHead>Estado</TableHead>
@@ -70,9 +65,9 @@ export function BudgetsTable() {
         <TableBody>
           {budgets.map((budget) => (
             <TableRow key={budget.id}>
-              <TableCell className="font-medium">{budget.number}</TableCell>
-              <TableCell>{budget.customer.name}</TableCell>
-              <TableCell>{formatCurrency(budget.total)}</TableCell>
+              <TableCell className="font-medium">{budget.id}</TableCell>
+              <TableCell>{budget.clientId}</TableCell>
+              <TableCell>{formatCurrency(parseFloat(budget.totalAmount), "ARS")}</TableCell>
               <TableCell>
                 <Badge
                   variant={
@@ -90,7 +85,7 @@ export function BudgetsTable() {
                     : "Rechazado"}
                 </Badge>
               </TableCell>
-              <TableCell>{formatDate(budget.createdAt)}</TableCell>
+              <TableCell>{formatDate(budget.dateCreated)}</TableCell>
               <TableCell>
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,6 +1,9 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
 
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3001";
+// Base URL used by the helper methods below. By default we rely on a
+// relative path so the API requests go to the same origin as the
+// frontend, which is the case in development.
+const API_URL = import.meta.env.VITE_API_URL || "";
 
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -1,4 +1,5 @@
-#export async function createSale(saleData: any) {
+/*
+export async function createSale(saleData: any) {
   try {
     // Verificar si la sesión está activa antes de hacer la petición
     const response = await fetch(`${this.baseUrl}/api/sales`, {
@@ -30,4 +31,7 @@
     console.error('Error al crear la venta:', error);
     throw error;
   }
-} 
+}
+*/
+
+export {};

--- a/client/src/services/quotationService.ts
+++ b/client/src/services/quotationService.ts
@@ -1,7 +1,10 @@
 import { QuotationWithItems, QuotationFormData } from "../types/quotation";
 import { apiRequest } from "@/lib/queryClient";
 
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3000/api";
+// Base URL for API requests. When VITE_API_URL is not provided we
+// fallback to "/api" so requests are made relative to the current
+// origin (the backend runs on the same server during development).
+const API_URL = import.meta.env.VITE_API_URL || "/api";
 
 export const quotationService = {
   async createQuotation(data: QuotationFormData): Promise<QuotationWithItems> {


### PR DESCRIPTION
## Summary
- integrate budget form with quotation API
- fetch quotes in budgets table
- comment out unused API service
- correct default API URL so quotes use the same server port

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685e93fd22648331b1dcf6ca9fcea0a0