### PR TITLE
Fix budgets table error

### DIFF
--- a/client/src/components/budgets/budgets-table.tsx
+++ b/client/src/components/budgets/budgets-table.tsx
@@ -29,7 +29,15 @@ export function BudgetsTable() {
     const load = async () => {
       try {
         const data = await quotationService.getQuotations();
-        setBudgets(data);
+        if (Array.isArray(data)) {
+          setBudgets(data);
+        } else {
+          console.error("Unexpected data format while fetching quotations", data);
+          setBudgets([]);
+        }
+      } catch (err) {
+        console.error("Error loading quotations", err);
+        setBudgets([]);
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
## Summary
- handle invalid data from `getQuotations` in `BudgetsTable`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685f124739688331bd458fa688ed55c7