### PR TITLE
Fix web order submission

### DIFF
--- a/client/src/pages/orders.tsx
+++ b/client/src/pages/orders.tsx
@@ -69,6 +69,7 @@ interface Order {
   deliveryMethod: string;
   route?: Route;
   shippingInfo?: string;
+  source?: string;
 }
 
 interface OrderItem {
@@ -779,6 +780,7 @@ export default function OrdersPage() {
                           <TableHead>Fecha</TableHead>
                           <TableHead>Entrega</TableHead>
                           <TableHead>Método</TableHead>
+                          <TableHead>Origen</TableHead>
                           <TableHead>Total</TableHead>
                           <TableHead>Estado</TableHead>
                           <TableHead className="text-right">Acciones</TableHead>
@@ -787,7 +789,7 @@ export default function OrdersPage() {
                       <TableBody>
                         {isLoading ? (
                           <TableRow>
-                            <TableCell colSpan={8} className="text-center py-10">
+                            <TableCell colSpan={9} className="text-center py-10">
                               Cargando pedidos...
                             </TableCell>
                           </TableRow>
@@ -823,6 +825,11 @@ export default function OrdersPage() {
                                     Sin asignar
                                   </Badge>
                                 )}
+                              </TableCell>
+                              <TableCell>
+                                <Badge variant="outline" className={order.source === 'web' ? 'bg-blue-100 text-blue-800' : 'bg-gray-100 text-gray-800'}>
+                                  {order.source === 'web' ? 'Web' : 'Manual'}
+                                </Badge>
                               </TableCell>
                               <TableCell>${parseFloat(order.total).toFixed(2)}</TableCell>
                               <TableCell>

--- a/client/src/pages/web/checkout-page.tsx
+++ b/client/src/pages/web/checkout-page.tsx
@@ -72,6 +72,7 @@ const CheckoutPage = () => {
     try {
       // Crear el objeto de la orden
       const orderData = {
+        cartId: cart?.id,
         customerData: {
           name: data.name,
           email: data.email,
@@ -86,11 +87,18 @@ const CheckoutPage = () => {
 
       // Enviar la orden al servidor
       const response = await apiRequest("POST", "/api/web/orders", orderData);
-      
+
       if (!response.ok) {
-        throw new Error("Error al procesar el pedido");
+        let message = "Error al procesar el pedido";
+        try {
+          const data = await response.json();
+          message = data.message || message;
+        } catch (_) {
+          // ignore json parse errors
+        }
+        throw new Error(message);
       }
-      
+
       const result = await response.json();
       
       // Limpiar el carrito después de la orden exitosa


### PR DESCRIPTION
## Summary
- include `cartId` when sending web orders
- surface server error message if order submission fails

## Testing
- `npm run check` *(fails: Cannot find type definition file due to no network)*

------
https://chatgpt.com/codex/tasks/task_e_685ee81459b0833187ab3a802be781bc