### PR TITLE
Fix checkout totals calculation

### DIFF
--- a/client/src/pages/web/checkout-page.tsx
+++ b/client/src/pages/web/checkout-page.tsx
@@ -72,6 +72,7 @@ const CheckoutPage = () => {
     try {
       // Crear el objeto de la orden
       const orderData = {
+        cartId: cart?.id,
         customerData: {
           name: data.name,
           email: data.email,
@@ -80,8 +81,6 @@ const CheckoutPage = () => {
           notes: data.notes || "",
         },
         paymentMethod: data.paymentMethod,
-        items: cartItems,
-        total: calculateTotal(),
       };
 
       // Enviar la orden al servidor
@@ -117,7 +116,10 @@ const CheckoutPage = () => {
 
   // Calcular el total de la orden
   const calculateTotal = () => {
-    return cartItems.reduce((sum, item) => sum + parseFloat(item.total), 0).toFixed(2);
+    return cartItems
+      .reduce((sum, item) =>
+        sum + parseFloat(item.price) * parseFloat(item.quantity), 0)
+      .toFixed(2);
   };
 
   return (
@@ -280,17 +282,23 @@ const CheckoutPage = () => {
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="space-y-2">
-                  {cartItems.map((item) => (
-                    <div key={item.id} className="flex justify-between items-start py-2 border-b">
-                      <div>
-                        <p className="font-medium">{item.productName}</p>
-                        <p className="text-sm text-muted-foreground">
-                          {item.quantity} {item.unit} x ${parseFloat(item.price).toFixed(2)}
-                        </p>
+                  {cartItems.map((item) => {
+                    const price = parseFloat(item.price);
+                    const quantity = parseFloat(item.quantity);
+                    const itemTotal = price * quantity;
+
+                    return (
+                      <div key={item.id} className="flex justify-between items-start py-2 border-b">
+                        <div>
+                          <p className="font-medium">{item.productName}</p>
+                          <p className="text-sm text-muted-foreground">
+                            {item.quantity} {item.unit} x ${price.toFixed(2)}
+                          </p>
+                        </div>
+                        <p className="font-medium">${itemTotal.toFixed(2)}</p>
                       </div>
-                      <p className="font-medium">${parseFloat(item.total).toFixed(2)}</p>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               </CardContent>
               <CardFooter className="flex justify-between border-t pt-4">


### PR DESCRIPTION
## Summary
- handle totals calculation on checkout correctly
- include cart id when posting web orders

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685f129c62f08331aa360aedc540bf58