### PR TITLE
Add edit and delete capabilities for credit notes

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -66,6 +66,7 @@ export interface IStorage {
   getAccountTransaction(id: number): Promise<AccountTransaction | undefined>;
   getAccountTransactions(accountId: number): Promise<AccountTransaction[]>;
   createAccountTransaction(transaction: InsertAccountTransaction): Promise<AccountTransaction>;
+  deleteAccountTransaction(id: number): Promise<void>;
   
   // Sales
   getSale(id: number): Promise<Sale | undefined>;
@@ -625,13 +626,17 @@ export class MemStorage implements IStorage {
   
   async createAccountTransaction(insertTransaction: InsertAccountTransaction): Promise<AccountTransaction> {
     const id = this.accountTransactionIdCounter++;
-    const transaction: AccountTransaction = { 
-      ...insertTransaction, 
+    const transaction: AccountTransaction = {
+      ...insertTransaction,
       id,
-      timestamp: new Date() 
+      timestamp: new Date()
     };
     this.accountTransactions.set(id, transaction);
     return transaction;
+  }
+
+  async deleteAccountTransaction(id: number): Promise<void> {
+    this.accountTransactions.delete(id);
   }
   
   // Sales


### PR DESCRIPTION
## Summary
- extend storage with `deleteAccountTransaction`
- add GET/PUT/DELETE API routes for notes
- add UI for editing/deleting credit or debit notes
- include edit dialog and row actions in notes table

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685fe0ff886083319283afcb2b728382