### PR TITLE
Add search and sort to products API

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,21 @@ This project contains a point-of-sale application with a React frontend and an E
 The server requires a `SESSION_SECRET` environment variable for managing user sessions. The
 application will throw an error during startup if this variable is not defined.
 
+## Development
+
+Install dependencies and start the application in development mode:
+
+```bash
+npm install
+npm run dev
+```
+
+The server listens on port `5000` by default.
+
+### Products API
+
+`GET /api/products` now accepts optional query parameters:
+
+- `search`: filter products by name or description (case insensitive).
+- `sort`: order results by `name` or `price`.
+

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -289,10 +289,32 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Products endpoints
   app.get("/api/products", async (req, res) => {
     try {
-      const products = await storage.getAllProducts();
+      let products = await storage.getAllProducts();
+
+      // Optional search by name or description
+      const search = (req.query.search as string | undefined)?.toLowerCase();
+      if (search) {
+        products = products.filter((p) =>
+          p.name.toLowerCase().includes(search) ||
+          (p.description?.toLowerCase().includes(search))
+        );
+      }
+
+      // Optional sorting by name or price
+      const sort = req.query.sort as string | undefined;
+      if (sort === "name") {
+        products = products.sort((a, b) => a.name.localeCompare(b.name));
+      } else if (sort === "price") {
+        products = products.sort(
+          (a, b) => parseFloat(a.price || "0") - parseFloat(b.price || "0"),
+        );
+      }
+
       res.json(products);
     } catch (error) {
-      res.status(500).json({ message: "Error al obtener productos", error: (error as Error).message });
+      res
+        .status(500)
+        .json({ message: "Error al obtener productos", error: (error as Error).message });
     }
   });
 


### PR DESCRIPTION
## Summary
- improve `/api/products` endpoint with `search` and `sort`
- document how to run the dev server
- document new query parameters

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node', 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6861bed212548331a44efbd996620ab7