### PR TITLE
Add production orders module

### DIFF
--- a/server/api/production-orders.ts
+++ b/server/api/production-orders.ts
@@ -1,0 +1,32 @@
+import { storage } from "../storage";
+import { z } from "zod";
+
+const productionOrderSchema = z.object({
+  productId: z.number(),
+  quantity: z.number(),
+  unit: z.string(),
+  status: z.string().optional(),
+  startDate: z.coerce.date().optional(),
+  endDate: z.coerce.date().optional(),
+  notes: z.string().nullable().optional()
+});
+
+export type ProductionOrderData = z.infer<typeof productionOrderSchema>;
+
+export async function getProductionOrders() {
+  return storage.getAllProductionOrders();
+}
+
+export async function createProductionOrder(data: ProductionOrderData) {
+  const validated = productionOrderSchema.parse(data);
+  return storage.createProductionOrder(validated);
+}
+
+export async function updateProductionOrder(id: number, data: Partial<ProductionOrderData>) {
+  const validated = productionOrderSchema.partial().parse(data);
+  return storage.updateProductionOrder(id, validated);
+}
+
+export async function deleteProductionOrder(id: number) {
+  return storage.deleteProductionOrder(id);
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import passport from "passport";
 import { Router } from "express";
 import { getBankAccounts, createBankAccount, updateBankAccount, deleteBankAccount } from "./api/bank-accounts";
+import { getProductionOrders, createProductionOrder, updateProductionOrder, deleteProductionOrder } from "./api/production-orders";
 import {
   InsertSale,
   InsertSaleItem,
@@ -4685,6 +4686,45 @@ const updateData: any = {
       res.json({ success: true });
     } catch (error) {
       res.status(400).json({ message: "Error al eliminar cuenta bancaria", error: (error as Error).message });
+    }
+  });
+
+  // Production Orders endpoints
+  app.get("/api/production-orders", async (req, res) => {
+    try {
+      const orders = await getProductionOrders();
+      res.json(orders);
+    } catch (error) {
+      res.status(500).json({ message: "Error al obtener órdenes de producción", error: (error as Error).message });
+    }
+  });
+
+  app.post("/api/production-orders", async (req, res) => {
+    try {
+      const order = await createProductionOrder(req.body);
+      res.status(201).json(order);
+    } catch (error) {
+      res.status(400).json({ message: "Error al crear orden de producción", error: (error as Error).message });
+    }
+  });
+
+  app.put("/api/production-orders/:id", async (req, res) => {
+    try {
+      const id = parseInt(req.params.id);
+      const order = await updateProductionOrder(id, req.body);
+      res.json(order);
+    } catch (error) {
+      res.status(400).json({ message: "Error al actualizar orden de producción", error: (error as Error).message });
+    }
+  });
+
+  app.delete("/api/production-orders/:id", async (req, res) => {
+    try {
+      const id = parseInt(req.params.id);
+      await deleteProductionOrder(id);
+      res.json({ success: true });
+    } catch (error) {
+      res.status(400).json({ message: "Error al eliminar orden de producción", error: (error as Error).message });
     }
   });
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -889,6 +889,31 @@ export const insertBankAccountSchema = createInsertSchema(bankAccounts).pick({
 export type BankAccount = typeof bankAccounts.$inferSelect;
 export type InsertBankAccount = z.infer<typeof insertBankAccountSchema>;
 
+// Production orders table
+export const productionOrders = pgTable("production_orders", {
+  id: serial("id").primaryKey(),
+  productId: integer("product_id").notNull().references(() => products.id),
+  quantity: numeric("quantity", { precision: 10, scale: 2 }).notNull(),
+  unit: text("unit").notNull(),
+  status: text("status").notNull().default("planned"), // planned, in_progress, completed, cancelled
+  startDate: timestamp("start_date"),
+  endDate: timestamp("end_date"),
+  notes: text("notes"),
+});
+
+export const insertProductionOrderSchema = createInsertSchema(productionOrders).pick({
+  productId: true,
+  quantity: true,
+  unit: true,
+  status: true,
+  startDate: true,
+  endDate: true,
+  notes: true,
+});
+
+export type ProductionOrder = typeof productionOrders.$inferSelect;
+export type InsertProductionOrder = z.infer<typeof insertProductionOrderSchema>;
+
 // Quotations table
 export const quotations = pgTable("quotations", {
   id: serial("id").primaryKey(),


### PR DESCRIPTION
## Summary
- add `productionOrders` table and insert schema
- support production orders in memory storage
- expose production order APIs
- wire production order endpoints

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6861beb7056c833195e2895c275d3877