### PR TITLE
Fix quotation form validation

### DIFF
--- a/client/src/pages/QuotationFormPage.tsx
+++ b/client/src/pages/QuotationFormPage.tsx
@@ -28,7 +28,7 @@ import { apiRequest } from "@/lib/queryClient";
 const quotationFormSchema = z.object({
   clientId: z.number({
     required_error: "Por favor seleccione un cliente",
-  }),
+  }).min(1, "Por favor seleccione un cliente"),
   dateValidUntil: z.date({
     required_error: "Por favor seleccione una fecha de validez",
   }),


### PR DESCRIPTION
## Summary
- validate that a client must be selected when creating a quotation

## Testing
- `npm run check` *(fails: server/routes.ts(5092,1): error TS1005: '}' expected.)*

------
https://chatgpt.com/codex/tasks/task_e_6862be6fa420833197a5cbd59bc12ac1