### PR TITLE
Link deliveries to orders or invoices

### DIFF
--- a/client/src/pages/logistics/deliveries-tab.tsx
+++ b/client/src/pages/logistics/deliveries-tab.tsx
@@ -251,6 +251,30 @@ export default function DeliveriesTab() {
     }
   });
 
+  // Obtener pedidos
+  const { data: orders, isLoading: isLoadingOrders } = useQuery<Order[]>({
+    queryKey: ["/api/orders"],
+    queryFn: async () => {
+      const response = await fetch("/api/orders");
+      if (!response.ok) {
+        throw new Error("Error al cargar pedidos");
+      }
+      return response.json();
+    }
+  });
+
+  // Obtener ventas/remitos
+  const { data: sales, isLoading: isLoadingSales } = useQuery<Sale[]>({
+    queryKey: ["/api/sales"],
+    queryFn: async () => {
+      const response = await fetch("/api/sales");
+      if (!response.ok) {
+        throw new Error("Error al cargar ventas");
+      }
+      return response.json();
+    }
+  });
+
   // Form para crear/editar entrega
   const form = useForm<z.infer<typeof deliverySchema>>({
     resolver: zodResolver(deliverySchema),
@@ -329,6 +353,8 @@ export default function DeliveriesTab() {
         requiresSignature: false,
         refrigerated: false,
         scheduledDate: new Date(),
+        orderId: undefined,
+        saleId: undefined,
       });
     },
     onError: (error) => {
@@ -553,7 +579,7 @@ export default function DeliveriesTab() {
   };
 
   // Renderizado condicional
-  if (isLoadingDeliveries || isLoadingCustomers || isLoadingDrivers || isLoadingVehicles || isLoadingRoutes) {
+  if (isLoadingDeliveries || isLoadingCustomers || isLoadingDrivers || isLoadingVehicles || isLoadingRoutes || isLoadingOrders || isLoadingSales) {
     return (
       <div className="flex justify-center items-center py-8">
         <Loader2 className="h-8 w-8 animate-spin text-primary" />
@@ -733,6 +759,62 @@ export default function DeliveriesTab() {
                                 <SelectItem value="mañana">Mañana (8:00 - 12:00)</SelectItem>
                                 <SelectItem value="tarde">Tarde (13:00 - 17:00)</SelectItem>
                                 <SelectItem value="completo">Día completo (8:00 - 17:00)</SelectItem>
+                              </SelectContent>
+                            </Select>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                      <FormField
+                        control={form.control}
+                        name="orderId"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Pedido (opcional)</FormLabel>
+                            <Select
+                              onValueChange={(value) => field.onChange(value ? parseInt(value) : undefined)}
+                              defaultValue={field.value?.toString()}
+                            >
+                              <FormControl>
+                                <SelectTrigger>
+                                  <SelectValue placeholder="Selecciona un pedido" />
+                                </SelectTrigger>
+                              </FormControl>
+                              <SelectContent>
+                                <SelectItem value="none">Sin pedido</SelectItem>
+                                {orders && orders.map(order => (
+                                  <SelectItem key={order.id} value={order.id.toString()}>
+                                    #{order.id} - {order.customer?.name || "Sin cliente"}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                      <FormField
+                        control={form.control}
+                        name="saleId"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Remito/Venta (opcional)</FormLabel>
+                            <Select
+                              onValueChange={(value) => field.onChange(value ? parseInt(value) : undefined)}
+                              defaultValue={field.value?.toString()}
+                            >
+                              <FormControl>
+                                <SelectTrigger>
+                                  <SelectValue placeholder="Selecciona un remito" />
+                                </SelectTrigger>
+                              </FormControl>
+                              <SelectContent>
+                                <SelectItem value="none">Sin remito</SelectItem>
+                                {sales && sales.map(sale => (
+                                  <SelectItem key={sale.id} value={sale.id.toString()}>
+                                    #{sale.id} - {sale.customer?.name || "Sin cliente"}
+                                  </SelectItem>
+                                ))}
                               </SelectContent>
                             </Select>
                             <FormMessage />
@@ -1239,6 +1321,18 @@ export default function DeliveriesTab() {
                             <p>Ruta: {selectedDelivery.route.name}</p>
                           </div>
                         )}
+                        {selectedDelivery.orderId && (
+                          <div className="flex items-start space-x-3">
+                            <Package className="h-4 w-4 mt-0.5" />
+                            <p>Pedido: #{selectedDelivery.orderId}</p>
+                          </div>
+                        )}
+                        {selectedDelivery.saleId && (
+                          <div className="flex items-start space-x-3">
+                            <Package className="h-4 w-4 mt-0.5" />
+                            <p>Remito: #{selectedDelivery.saleId}</p>
+                          </div>
+                        )}
                       </div>
                     </div>
                   </div>
@@ -1575,6 +1669,62 @@ export default function DeliveriesTab() {
                             <SelectItem value="mañana">Mañana (8:00 - 12:00)</SelectItem>
                             <SelectItem value="tarde">Tarde (13:00 - 17:00)</SelectItem>
                             <SelectItem value="completo">Día completo (8:00 - 17:00)</SelectItem>
+                          </SelectContent>
+                        </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="orderId"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Pedido (opcional)</FormLabel>
+                        <Select
+                          onValueChange={(value) => field.onChange(value ? parseInt(value) : undefined)}
+                          defaultValue={field.value?.toString()}
+                        >
+                          <FormControl>
+                            <SelectTrigger>
+                              <SelectValue placeholder="Selecciona un pedido" />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            <SelectItem value="none">Sin pedido</SelectItem>
+                            {orders && orders.map(order => (
+                              <SelectItem key={order.id} value={order.id.toString()}>
+                                #{order.id} - {order.customer?.name || "Sin cliente"}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="saleId"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Remito/Venta (opcional)</FormLabel>
+                        <Select
+                          onValueChange={(value) => field.onChange(value ? parseInt(value) : undefined)}
+                          defaultValue={field.value?.toString()}
+                        >
+                          <FormControl>
+                            <SelectTrigger>
+                              <SelectValue placeholder="Selecciona un remito" />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            <SelectItem value="none">Sin remito</SelectItem>
+                            {sales && sales.map(sale => (
+                              <SelectItem key={sale.id} value={sale.id.toString()}>
+                                #{sale.id} - {sale.customer?.name || "Sin cliente"}
+                              </SelectItem>
+                            ))}
                           </SelectContent>
                         </Select>
                         <FormMessage />

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1275,7 +1275,7 @@ export class MemStorage implements IStorage {
       customerId: delivery.customerId || null,
       userId: delivery.userId,
       saleId: delivery.saleId || null,
-      orderId: delivery.orderId,
+      orderId: delivery.orderId || null,
       trackingCode,
       scheduledDate: delivery.scheduledDate,
       estimatedDeliveryTime: delivery.estimatedDeliveryTime || null,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -488,7 +488,7 @@ export const insertDeliveryRouteSchema = createInsertSchema(deliveryRoutes).pick
 // Tabla de entregas
 export const deliveries = pgTable("deliveries", {
   id: serial("id").primaryKey(),
-  orderId: integer("order_id").notNull().references(() => orders.id),
+  orderId: integer("order_id").references(() => orders.id),
   saleId: integer("sale_id").references(() => sales.id),
   customerId: integer("customer_id").references(() => customers.id),
   userId: integer("user_id").notNull().references(() => users.id), // Usuario que creó la entrega


### PR DESCRIPTION
## Summary
- allow `orderId` to be optional in deliveries
- set default `orderId` to null when creating deliveries
- load orders and sales for deliveries screen
- support linking deliveries to an order or invoice in create/edit dialogs
- show related order or invoice in delivery details

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6862c03f45448331a901b1d5944edef6