### PR TITLE
Fix budget creation without customer

### DIFF
--- a/client/src/pages/pos.tsx
+++ b/client/src/pages/pos.tsx
@@ -560,6 +560,15 @@ const POSPage = () => {
         status = "pedido";
       }
 
+      if ((documentType === "presupuesto" || documentType === "pedido") && !selectedCustomerId) {
+        toast({
+          title: "Cliente requerido",
+          description: "Debe seleccionar un cliente para guardar el documento",
+          variant: "destructive",
+        });
+        return;
+      }
+
       const saleData = {
         customerId: selectedCustomerId,
         userId: user?.id,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -5012,8 +5012,8 @@ const updateData: any = {
     }
 
     try {
-      const quotations = await db.select().from(quotations).orderBy(quotations.dateCreated);
-      return res.json(quotations);
+      const quotationList = await db.select().from(quotations).orderBy(quotations.dateCreated);
+      return res.json(quotationList);
     } catch (error) {
       console.error("Error fetching quotations:", error);
       return res.status(500).json({ error: "Failed to fetch quotations" });


### PR DESCRIPTION
## Summary
- require a selected customer when saving a budget from POS
- fix quotations listing API

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68644d1cd6f8833192fd0c2928430d50