### PR TITLE
Fix web order note handling when no customer ID

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2944,13 +2944,30 @@ export async function registerRoutes(app: Express): Promise<Server> {
           };
         }
       }
+
+      // Si el pedido no está asociado a un cliente existente, 
+      // adjuntamos los datos proporcionados como parte de la nota
+      let notes = finalCustomerData.notes || "";
+      if (!resolvedCustomerId) {
+        const detailParts: string[] = [];
+        if (finalCustomerData.name) detailParts.push(`Nombre: ${finalCustomerData.name}`);
+        if (finalCustomerData.email) detailParts.push(`Email: ${finalCustomerData.email}`);
+        if (finalCustomerData.phone) detailParts.push(`Tel: ${finalCustomerData.phone}`);
+        if (finalCustomerData.address) detailParts.push(`Dirección: ${finalCustomerData.address}`);
+        if (finalCustomerData.city) detailParts.push(`Ciudad: ${finalCustomerData.city}`);
+        if (finalCustomerData.province) detailParts.push(`Provincia: ${finalCustomerData.province}`);
+        if (detailParts.length > 0) {
+          const detailsString = detailParts.join(', ');
+          notes = notes ? `${notes} - ${detailsString}` : detailsString;
+        }
+      }
       
       // Crear la orden
       const order = await storage.createOrder({
         userId: adminUser.id,
         total: total.toString(),
         status: "pending",
-        notes: finalCustomerData.notes || "",
+        notes,
         deliveryDate: new Date(Date.now() + 24 * 60 * 60 * 1000), // entrega al día siguiente
         isWebOrder: true,
         source: "web",


### PR DESCRIPTION
## Summary
- ensure customer details are appended to order notes if no customer ID is provided when placing a web order

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6864553b07888331ab35cfd57af278ee