### PR TITLE
Fix quotation endpoints for Express

### DIFF
--- a/client/src/pages/pos.tsx
+++ b/client/src/pages/pos.tsx
@@ -560,6 +560,15 @@ const POSPage = () => {
         status = "pedido";
       }
 
+      if ((documentType === "presupuesto" || documentType === "pedido") && !selectedCustomerId) {
+        toast({
+          title: "Cliente requerido",
+          description: "Debe seleccionar un cliente para guardar el documento",
+          variant: "destructive",
+        });
+        return;
+      }
+
       const saleData = {
         customerId: selectedCustomerId,
         userId: user?.id,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -5012,49 +5012,58 @@ const updateData: any = {
     }
 
     try {
-      const quotations = await db.select().from(quotations).orderBy(quotations.dateCreated);
-      return res.json(quotations);
+      const quotationList = await db.select().from(quotations).orderBy(quotations.dateCreated);
+      return res.json(quotationList);
     } catch (error) {
       console.error("Error fetching quotations:", error);
       return res.status(500).json({ error: "Failed to fetch quotations" });
     }
   });
 
-  app.get("/api/quotations/:id", async (c) => {
-    const userId = c.get("userId");
+  app.get("/api/quotations/:id", async (req, res) => {
+    const userId = req.user?.id;
     if (!userId) {
-      return c.json({ error: "Unauthorized" }, 401);
+      return res.status(401).json({ error: "Unauthorized" });
     }
 
-    const id = c.req.param("id");
+    const { id } = req.params;
 
     try {
-      const [quotation] = await db.select().from(quotations).where(eq(quotations.id, parseInt(id)));
+      const [quotation] = await db
+        .select()
+        .from(quotations)
+        .where(eq(quotations.id, parseInt(id)));
       if (!quotation) {
-        return c.json({ error: "Quotation not found" }, 404);
+        return res.status(404).json({ error: "Quotation not found" });
       }
 
-      const items = await db.select().from(quotationItems).where(eq(quotationItems.quotationId, quotation.id));
-      return c.json({ ...quotation, items });
+      const items = await db
+        .select()
+        .from(quotationItems)
+        .where(eq(quotationItems.quotationId, quotation.id));
+      return res.json({ ...quotation, items });
     } catch (error) {
       console.error("Error fetching quotation:", error);
-      return c.json({ error: "Failed to fetch quotation" }, 500);
+      return res.status(500).json({ error: "Failed to fetch quotation" });
     }
   });
 
-  app.put("/api/quotations/:id/status", async (c) => {
-    const userId = c.get("userId");
+  app.put("/api/quotations/:id/status", async (req, res) => {
+    const userId = req.user?.id;
     if (!userId) {
-      return c.json({ error: "Unauthorized" }, 401);
+      return res.status(401).json({ error: "Unauthorized" });
     }
 
-    const id = c.req.param("id");
-    const { status } = await c.req.json();
+    const { id } = req.params;
+    const { status } = req.body;
 
     try {
-      const [quotation] = await db.select().from(quotations).where(eq(quotations.id, parseInt(id)));
+      const [quotation] = await db
+        .select()
+        .from(quotations)
+        .where(eq(quotations.id, parseInt(id)));
       if (!quotation) {
-        return c.json({ error: "Quotation not found" }, 404);
+        return res.status(404).json({ error: "Quotation not found" });
       }
 
       // Si el presupuesto es aprobado, crear una factura
@@ -5085,14 +5094,15 @@ const updateData: any = {
       }
 
       // Actualizar el estado del presupuesto
-      await db.update(quotations)
+      await db
+        .update(quotations)
         .set({ status })
         .where(eq(quotations.id, parseInt(id)));
 
-      return c.json({ success: true });
+      return res.json({ success: true });
     } catch (error) {
       console.error("Error updating quotation status:", error);
-      return c.json({ error: "Failed to update quotation status" }, 500);
+      return res.status(500).json({ error: "Failed to update quotation status" });
     }
   });
   // ... existing code ...


### PR DESCRIPTION
## Summary
- require a selected customer when saving a budget from POS
- fix quotations listing API
- convert quotation detail and status routes to Express-style handlers

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68644d1cd6f8833192fd0c2928430d50