### PR TITLE
Fix default wholesale price persistence

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -516,6 +516,7 @@ export class MemStorage implements IStorage {
       purchaseQty: insertProduct.purchaseQty || null,
       barcodes: insertProduct.barcodes || null,
       price: insertProduct.price || "0",
+      wholesalePrice: insertProduct.wholesalePrice || "0",
       cost: insertProduct.cost || null,
       packCost: insertProduct.packCost || null,
       stock: insertProduct.stock || "0",
@@ -533,7 +534,8 @@ export class MemStorage implements IStorage {
       imageUrl: insertProduct.imageUrl || null,
       iva: insertProduct.iva || "21",
       shipping: insertProduct.shipping || "0",
-      profit: insertProduct.profit || "30"
+      profit: insertProduct.profit || "30",
+      wholesaleProfit: insertProduct.wholesaleProfit || "35"
     };
     this.products.set(id, product);
     return product;


### PR DESCRIPTION
## Summary
- ensure wholesale prices and profit rates are set when creating products

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68645c56223c8331bc3fe3a8084968b8