### PR TITLE
Fix quotation cache invalidation

### DIFF
--- a/client/src/pages/pos.tsx
+++ b/client/src/pages/pos.tsx
@@ -188,8 +188,8 @@ const POSPage = () => {
     },
     onSuccess: (data) => {
       // Invalidar consultas según el tipo de documento
-      if (data.documentType === "presupuesto") {
-        queryClient.invalidateQueries({ queryKey: ["/api/presupuestos"] });
+        if (data.documentType === "presupuesto") {
+          queryClient.invalidateQueries({ queryKey: ["/api/quotations"] });
       } else if (data.documentType === "pedido") {
         queryClient.invalidateQueries({ queryKey: ["/api/orders"] });
       } else {


### PR DESCRIPTION
## Summary
- update POS page to correctly invalidate quotation list

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6864600676888331a131237cf228cf8c