### PR TITLE
Fix quotation creation response

### DIFF
--- a/client/src/pages/pos.tsx
+++ b/client/src/pages/pos.tsx
@@ -189,7 +189,7 @@ const POSPage = () => {
     onSuccess: (data) => {
       // Invalidar consultas según el tipo de documento
       if (data.documentType === "presupuesto") {
-        queryClient.invalidateQueries({ queryKey: ["/api/presupuestos"] });
+        queryClient.invalidateQueries({ queryKey: ["/api/quotations"] });
       } else if (data.documentType === "pedido") {
         queryClient.invalidateQueries({ queryKey: ["/api/orders"] });
       } else {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -5103,7 +5103,7 @@ const updateData: any = {
 
       await db.insert(quotationItems).values(quotationItemsData);
 
-      return res.status(201).json({ success: true, quotation });
+      return res.status(201).json(quotation);
     } catch (error) {
       console.error("Error creating quotation:", error);
       return res.status(500).json({ error: "Failed to create quotation" });


### PR DESCRIPTION
## Summary
- return the created quotation directly from the API
- fix cache invalidation key for quotations in POS page

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6864633247c883319dd5f2a799fe708d