### PR TITLE
Add stock movement support

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -5,6 +5,7 @@ import { setupAuth, hashPassword } from "./auth";
 import { z } from "zod";
 import passport from "passport";
 import { Router } from "express";
+import stockRoutes from "../src/routes/stockRoutes";
 import { getBankAccounts, createBankAccount, updateBankAccount, deleteBankAccount } from "./api/bank-accounts";
 import { getProductionOrders, createProductionOrder, updateProductionOrder, deleteProductionOrder } from "./api/production-orders";
 import { scrapePrices } from "./scraper";
@@ -24,6 +25,7 @@ import { eq } from "drizzle-orm";
 export async function registerRoutes(app: Express): Promise<Server> {
   // Sets up /api/register, /api/login, /api/logout, /api/user
   setupAuth(app);
+  app.use("/api", stockRoutes);
 
   // Dashboard endpoints
   app.get("/api/dashboard/stats", async (_req, res, next) => {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -980,8 +980,31 @@ export const insertQuotationItemSchema = createInsertSchema(quotationItems).pick
   subtotal: true,
 });
 
+// Stock movements table
+export const stockMovements = pgTable("stock_movements", {
+  id: serial("id").primaryKey(),
+  productId: integer("product_id").notNull().references(() => products.id),
+  type: text("type").notNull(), // 'entrada' | 'salida'
+  quantity: numeric("quantity", { precision: 10, scale: 2 }).notNull(),
+  reason: text("reason").notNull(),
+  date: timestamp("date").defaultNow(),
+  userId: integer("user_id").notNull().references(() => users.id),
+});
+
+export const insertStockMovementSchema = createInsertSchema(stockMovements).pick({
+  productId: true,
+  type: true,
+  quantity: true,
+  reason: true,
+  date: true,
+  userId: true,
+});
+
 // Types
 export type Quotation = typeof quotations.$inferSelect;
 export type InsertQuotation = z.infer<typeof insertQuotationSchema>;
 export type QuotationItem = typeof quotationItems.$inferSelect;
 export type InsertQuotationItem = z.infer<typeof insertQuotationItemSchema>;
+
+export type StockMovement = typeof stockMovements.$inferSelect;
+export type InsertStockMovement = z.infer<typeof insertStockMovementSchema>;

--- a/src/controllers/stockController.ts
+++ b/src/controllers/stockController.ts
@@ -1,0 +1,26 @@
+import { Request, Response } from 'express';
+import { storage } from '@server/storage';
+import { insertStockMovementSchema } from '@shared/schema';
+import { z } from 'zod';
+
+export async function createStockMovement(req: Request, res: Response) {
+  try {
+    const data = insertStockMovementSchema.parse(req.body);
+    const movement = await storage.createStockMovement(data);
+    res.status(201).json(movement);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ message: 'Datos inválidos', errors: error.errors });
+    }
+    res.status(500).json({ message: 'Error al registrar movimiento de stock' });
+  }
+}
+
+export async function listStockMovements(_req: Request, res: Response) {
+  try {
+    const movements = await storage.getAllStockMovements();
+    res.json(movements);
+  } catch (error) {
+    res.status(500).json({ message: 'Error al obtener movimientos' });
+  }
+}

--- a/src/routes/stockRoutes.ts
+++ b/src/routes/stockRoutes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { createStockMovement, listStockMovements } from '../controllers/stockController';
+
+const router = Router();
+
+router.post('/stock/movimientos', createStockMovement);
+router.get('/stock/movimientos', listStockMovements);
+
+export default router;


### PR DESCRIPTION
## Summary
- add StockMovement model to schema
- extend storage with stock movement maps and methods
- create controller and routes for StockMovement
- register new routes in Express

## Testing
- `npm run check` *(fails: Cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_686527e5d63c8331b169ec7fec833a3f