### PR TITLE
Add reorder point and low stock endpoint

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -21,6 +21,15 @@ import {
 import { db } from "./db";
 import { eq } from "drizzle-orm";
 
+async function getProductosConStockBajo() {
+  const productos = await storage.getAllProducts();
+  return productos.filter(p =>
+    p.puntoReposicion !== null &&
+    p.puntoReposicion !== undefined &&
+    parseFloat(p.stock?.toString() || "0") <= parseFloat(p.puntoReposicion!.toString())
+  );
+}
+
 export async function registerRoutes(app: Express): Promise<Server> {
   // Sets up /api/register, /api/login, /api/logout, /api/user
   setupAuth(app);
@@ -242,6 +251,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res
         .status(500)
         .json({ message: "Error al obtener productos", error: (error as Error).message });
+    }
+  });
+
+  app.get("/api/products/stock-bajo", async (_req, res) => {
+    try {
+      const productos = await getProductosConStockBajo();
+      res.json(productos);
+    } catch (error) {
+      res.status(500).json({ message: "Error al obtener productos con stock bajo", error: (error as Error).message });
     }
   });
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -529,6 +529,7 @@ export class MemStorage implements IStorage {
       packCost: insertProduct.packCost || null,
       stock: insertProduct.stock || "0",
       stockAlert: insertProduct.stockAlert || null,
+      puntoReposicion: insertProduct.puntoReposicion || null,
       webVisible: insertProduct.webVisible ?? true,
       isRefrigerated: insertProduct.isRefrigerated ?? false,
       isComposite: insertProduct.isComposite ?? false,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -89,6 +89,7 @@ export const products = pgTable("products", {
   stock: numeric("stock", { precision: 10, scale: 2 }).notNull().default("0"),
   reservedStock: numeric("reserved_stock", { precision: 10, scale: 2 }).notNull().default("0"),
   stockAlert: numeric("stock_alert", { precision: 10, scale: 2 }),
+  puntoReposicion: numeric("punto_reposicion", { precision: 10, scale: 2 }),
   supplierId: integer("supplier_id").references(() => suppliers.id),
   // Unidad en la que se compra el producto (ej. caja)
   purchaseUnit: text("purchase_unit"),
@@ -139,6 +140,7 @@ export const insertProductSchema = createInsertSchema(products).pick({
   costCurrency: true,
   stock: true,
   stockAlert: true,
+  puntoReposicion: true,
   supplierId: true,
   purchaseUnit: true,
   purchaseQty: true,


### PR DESCRIPTION
## Summary
- extend `products` schema with `puntoReposicion`
- support `puntoReposicion` in memory storage
- expose helper `getProductosConStockBajo()` and `/api/products/stock-bajo` route

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68652ba9a30c8331ad3b5af16ce95512