### PR TITLE
Add export sales report

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "escpos-printer-toolkit": "^1.0.8",
     "express": "^4.21.2",
     "express-session": "^1.18.1",
+    "exceljs": "^4.3.0",
     "framer-motion": "^11.13.1",
     "html-to-image": "^1.11.13",
     "input-otp": "^1.2.4",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -11,6 +11,10 @@ import { getProductionOrders, createProductionOrder, updateProductionOrder, dele
 import { scrapePrices } from "./scraper";
 import { checkAfipStatus, createAfipInvoice } from "./api/afip";
 import { getStats } from "./services/dashboardService";
+import ExcelJS from "exceljs";
+import fs from "fs";
+import os from "os";
+import path from "path";
 import {
   InsertSale,
   InsertSaleItem,
@@ -4529,6 +4533,58 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       console.error("Error al generar reporte de productos rentables:", error);
       res.status(500).json({ error: "Error al generar reporte de productos rentables" });
+    }
+  });
+
+  app.get("/api/reports/ventas/exportar", async (req, res) => {
+    try {
+      const desdeParam = req.query.desde as string | undefined;
+      const hastaParam = req.query.hasta as string | undefined;
+
+      const desde = desdeParam ? new Date(desdeParam) : new Date("1970-01-01");
+      const hasta = hastaParam ? new Date(hastaParam) : new Date();
+      hasta.setHours(23, 59, 59, 999);
+
+      const allSales = await storage.getAllSales() || [];
+      const customers = await storage.getAllCustomers() || [];
+
+      const filteredSales = allSales.filter(sale => {
+        const saleDate = new Date(sale.timestamp as string);
+        return saleDate >= desde && saleDate <= hasta;
+      });
+
+      const workbook = new ExcelJS.Workbook();
+      const worksheet = workbook.addWorksheet("Ventas");
+
+      worksheet.columns = [
+        { header: "ID", key: "id", width: 10 },
+        { header: "Fecha", key: "fecha", width: 15 },
+        { header: "Cliente", key: "cliente", width: 30 },
+        { header: "Total", key: "total", width: 15 }
+      ];
+
+      for (const sale of filteredSales) {
+        const customer = sale.customerId ? customers.find(c => c.id === sale.customerId) : undefined;
+        worksheet.addRow({
+          id: sale.id,
+          fecha: new Date(sale.timestamp as string).toLocaleDateString(),
+          cliente: customer ? customer.name : "Cliente no registrado",
+          total: parseFloat(sale.total).toFixed(2)
+        });
+      }
+
+      const tmpPath = path.join(os.tmpdir(), `ventas_${Date.now()}.xlsx`);
+      await workbook.xlsx.writeFile(tmpPath);
+
+      res.download(tmpPath, "ventas.xlsx", err => {
+        fs.unlink(tmpPath, () => {});
+        if (err) {
+          console.error("Error al descargar archivo de ventas:", err);
+        }
+      });
+    } catch (error) {
+      console.error("Error al exportar ventas:", error);
+      res.status(500).json({ error: "Error al exportar ventas" });
     }
   });
 


### PR DESCRIPTION
## Summary
- add exceljs dependency
- implement `/api/reports/ventas/exportar` endpoint to export sales filtered by dates

## Testing
- `npm run check` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_68652c32d21483319ff63cbac75a6f7d