### PR TITLE
Rename budgets components to quotations

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,7 +10,7 @@ import { ProtectedRoute } from "@/lib/protected-route";
 import { RouterProvider } from "@/lib/router-provider";
 import { useEffect } from "react";
 import { QuotationRoutes } from "@/routes";
-import BudgetsPage from "@/pages/budgets";
+import QuotationsPage from "@/pages/quotations";
 
 // Admin Panel Pages
 import Dashboard from "@/pages/dashboard";
@@ -75,7 +75,7 @@ function AppRoutes() {
       <ProtectedRoute path="/users" component={UsersPage} />
       <ProtectedRoute path="/settings" component={SettingsPage} />
       <ProtectedRoute path="/purchases" component={PurchasesPage} />
-      <ProtectedRoute path="/budgets" component={BudgetsPage} />
+      <ProtectedRoute path="/quotations" component={QuotationsPage} />
       
       {/* Web Catalog Routes */}
       <Route path="/web">

--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -165,7 +165,7 @@ export default function Sidebar() {
           <SidebarLink href="/credit-notes" icon={<FileEdit className="h-4 w-4" />} currentPath={location} onClick={closeSidebar}>
             Notas de Crédito/Débito
           </SidebarLink>
-          <SidebarLink href="/budgets" icon={<DollarSign className="h-4 w-4" />} currentPath={location} onClick={closeSidebar}>
+          <SidebarLink href="/quotations" icon={<DollarSign className="h-4 w-4" />} currentPath={location} onClick={closeSidebar}>
             Presupuestos
           </SidebarLink>
           

--- a/client/src/components/quotations/quotation-form-dialog.tsx
+++ b/client/src/components/quotations/quotation-form-dialog.tsx
@@ -20,7 +20,7 @@ import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { formatCurrency } from "@/lib/utils";
 
-interface BudgetFormDialogProps {
+interface QuotationFormDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
@@ -36,7 +36,7 @@ interface CartItem {
   stockAvailable: number;
 }
 
-export function BudgetFormDialog({ open, onOpenChange }: BudgetFormDialogProps) {
+export function QuotationFormDialog({ open, onOpenChange }: QuotationFormDialogProps) {
   const { toast } = useToast();
   const [searchQuery, setSearchQuery] = useState("");
   const [cart, setCart] = useState<CartItem[]>([]);
@@ -139,7 +139,7 @@ export function BudgetFormDialog({ open, onOpenChange }: BudgetFormDialogProps) 
     }
 
     try {
-      const budgetData = {
+      const quotationData = {
         customerId: selectedCustomerId,
         items: cart.map((item) => ({
           productId: item.productId,
@@ -159,12 +159,12 @@ export function BudgetFormDialog({ open, onOpenChange }: BudgetFormDialogProps) 
       };
 
       await apiRequest("POST", "/api/quotations", {
-        clientId: budgetData.customerId,
+        clientId: quotationData.customerId,
         dateValidUntil: new Date(
-          Date.now() + budgetData.validityDays * 24 * 60 * 60 * 1000
+          Date.now() + quotationData.validityDays * 24 * 60 * 60 * 1000
         ).toISOString(),
-        notes: budgetData.observations,
-        items: budgetData.items.map((i) => ({
+        notes: quotationData.observations,
+        items: quotationData.items.map((i) => ({
           productId: i.productId,
           quantity: i.quantity,
           unitPrice: i.price,

--- a/client/src/components/quotations/quotations-table.tsx
+++ b/client/src/components/quotations/quotations-table.tsx
@@ -21,8 +21,8 @@ import { formatCurrency } from "@/lib/utils";
 import { quotationService } from "@/services/quotationService";
 import { Quotation } from "@/types/quotation";
 
-export function BudgetsTable() {
-  const [budgets, setBudgets] = useState<Quotation[]>([]);
+export function QuotationsTable() {
+  const [quotations, setQuotations] = useState<Quotation[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -30,14 +30,14 @@ export function BudgetsTable() {
       try {
         const data = await quotationService.getQuotations();
         if (Array.isArray(data)) {
-          setBudgets(data);
+          setQuotations(data);
         } else {
           console.error("Unexpected data format while fetching quotations", data);
-          setBudgets([]);
+          setQuotations([]);
         }
       } catch (err) {
         console.error("Error loading quotations", err);
-        setBudgets([]);
+        setQuotations([]);
       } finally {
         setLoading(false);
       }
@@ -71,7 +71,7 @@ export function BudgetsTable() {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {budgets.map((budget) => (
+          {quotations.map((budget) => (
             <TableRow key={budget.id}>
               <TableCell className="font-medium">{budget.id}</TableCell>
               <TableCell>{budget.clientId}</TableCell>
@@ -104,7 +104,7 @@ export function BudgetsTable() {
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
                     <DropdownMenuItem asChild>
-                      <Link href={`/budgets/${budget.id}`}>
+                      <Link href={`/quotations/${budget.id}`}>
                         <FileText className="mr-2 h-4 w-4" />
                         Ver Detalles
                       </Link>

--- a/client/src/pages/quotations.tsx
+++ b/client/src/pages/quotations.tsx
@@ -3,11 +3,11 @@ import { useLocation } from "wouter";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
 import { useAuth } from "@/hooks/use-auth";
-import { BudgetsTable } from "@/components/budgets/budgets-table";
-import { BudgetFormDialog } from "@/components/budgets/budget-form-dialog";
+import { QuotationsTable } from "@/components/quotations/quotations-table";
+import { QuotationFormDialog } from "@/components/quotations/quotation-form-dialog";
 import { DashboardLayout } from "@/layouts/dashboard-layout";
 
-export default function BudgetsPage() {
+export default function QuotationsPage() {
   const [location] = useLocation();
   const { user } = useAuth();
   const [isFormOpen, setIsFormOpen] = useState(false);
@@ -23,9 +23,9 @@ export default function BudgetsPage() {
         </Button>
       </div>
 
-      <BudgetsTable />
+      <QuotationsTable />
 
-      <BudgetFormDialog
+      <QuotationFormDialog
         open={isFormOpen}
         onOpenChange={setIsFormOpen}
       />


### PR DESCRIPTION
## Summary
- rename BudgetsPage -> QuotationsPage
- rename BudgetsTable -> QuotationsTable
- rename BudgetFormDialog -> QuotationFormDialog
- update routes and sidebar link to `/quotations`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68653622b5b08331912c35ca99b1ab3b