### PR TITLE
Fix undefined quotations map

### DIFF
--- a/client/src/pages/QuotationsPage.tsx
+++ b/client/src/pages/QuotationsPage.tsx
@@ -75,11 +75,12 @@ export default function QuotationsPage() {
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
-            {quotations.map((quotation) => (
-              <tr key={quotation.id}>
-                <td className="px-6 py-4 whitespace-nowrap">
-                  {quotation.clientId}
-                </td>
+            {Array.isArray(quotations) ? (
+              quotations.map((quotation) => (
+                <tr key={quotation.id}>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    {quotation.clientId}
+                  </td>
                 <td className="px-6 py-4 whitespace-nowrap">
                   {formatDate(quotation.dateCreated)}
                 </td>
@@ -127,7 +128,12 @@ export default function QuotationsPage() {
                   )}
                 </td>
               </tr>
-            ))}
+              ))
+            ) : (
+              <tr>
+                <td colSpan={6}>No hay presupuestos disponibles.</td>
+              </tr>
+            )}
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
## Summary
- handle cases where `quotations` may not be an array in `QuotationsPage`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68653fb568c08331aa6e946d09d16c1b