### PR TITLE
feat: introduce rbac foundation with guard and seed

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,6 +8,7 @@
     "build": "nest build",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
+    "prisma:seed": "ts-node ../../prisma/seed.ts",
     "test": "jest"
   },
   "dependencies": {

--- a/apps/api/src/auth/permissions.decorator.ts
+++ b/apps/api/src/auth/permissions.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const PERMISSIONS_KEY = 'permissions';
+export const Permissions = (...permissions: string[]) =>
+  SetMetadata(PERMISSIONS_KEY, permissions);

--- a/apps/api/src/auth/permissions.guard.spec.ts
+++ b/apps/api/src/auth/permissions.guard.spec.ts
@@ -1,0 +1,40 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { PermissionsGuard } from './permissions.guard';
+
+describe('PermissionsGuard', () => {
+  const reflector = new Reflector();
+  const prisma = {
+    user: {
+      findUnique: jest.fn(),
+    },
+  } as any;
+  const guard = new PermissionsGuard(reflector, prisma);
+
+  const context: any = {
+    switchToHttp: () => ({ getRequest: () => ({ user: { id: 'user1' } }) }),
+    getHandler: () => null,
+  };
+
+  it('allows when user has permission', async () => {
+    reflector.get = jest.fn().mockReturnValue(['canCloseCash']);
+    prisma.user.findUnique.mockResolvedValue({
+      roles: [
+        {
+          role: {
+            permissions: [{ permission: { name: 'canCloseCash' } }],
+          },
+        },
+      ],
+    });
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+  });
+
+  it('throws when missing permission', async () => {
+    reflector.get = jest.fn().mockReturnValue(['canCloseCash']);
+    prisma.user.findUnique.mockResolvedValue({ roles: [] });
+    await expect(guard.canActivate(context)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+});

--- a/apps/api/src/auth/permissions.guard.ts
+++ b/apps/api/src/auth/permissions.guard.ts
@@ -1,0 +1,69 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { PrismaService } from '../prisma.service';
+import { PERMISSIONS_KEY } from './permissions.decorator';
+
+interface CacheEntry {
+  permissions: string[];
+  expires: number;
+}
+
+@Injectable()
+export class PermissionsGuard implements CanActivate {
+  private cache = new Map<string, CacheEntry>();
+
+  constructor(private reflector: Reflector, private prisma: PrismaService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const required =
+      this.reflector.get<string[]>(PERMISSIONS_KEY, context.getHandler()) || [];
+    if (required.length === 0) return true;
+
+    const req = context.switchToHttp().getRequest();
+    const userId: string | undefined = req.user?.id;
+    if (!userId) throw new ForbiddenException('User not authenticated');
+
+    const permissions = await this.getPermissions(userId);
+    req.user.permissions = permissions;
+
+    const missing = required.filter((p) => !permissions.includes(p));
+    if (missing.length > 0)
+      throw new ForbiddenException('Missing permissions');
+    return true;
+  }
+
+  private async getPermissions(userId: string): Promise<string[]> {
+    const cached = this.cache.get(userId);
+    const now = Date.now();
+    if (cached && cached.expires > now) return cached.permissions;
+
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      include: {
+        roles: {
+          include: {
+            role: {
+              include: {
+                permissions: { include: { permission: true } },
+              },
+            },
+          },
+        },
+      },
+    });
+    const perms =
+      user?.roles.flatMap((r) =>
+        r.role.permissions.map((p) => p.permission.name),
+      ) || [];
+    this.cache.set(userId, {
+      permissions: perms,
+      expires: now + 5 * 60 * 1000,
+    });
+    return perms;
+  }
+}

--- a/apps/api/src/cash-register/cash-register.controller.ts
+++ b/apps/api/src/cash-register/cash-register.controller.ts
@@ -1,8 +1,19 @@
-import { Body, Controller, Get, Post, Query, Req } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import { CashSessionsService } from '../cash-sessions/cash-sessions.service';
 import { CashMovementsService } from '../cash-movements/cash-movements.service';
 import { CashMovementType, PaymentMethod } from '@prisma/client';
+import { Permissions } from '../auth/permissions.decorator';
+import { PermissionsGuard } from '../auth/permissions.guard';
 
+@UseGuards(PermissionsGuard)
 @Controller('cash-register')
 export class CashRegisterController {
   constructor(
@@ -11,18 +22,29 @@ export class CashRegisterController {
   ) {}
 
   @Post('open')
+  @Permissions('canOpenCash')
   open(@Body() body: any, @Req() req: any) {
-    return this.sessions.open(body.cashRegisterId, Number(body.openingAmount || 0), req.user);
+    return this.sessions.open(
+      body.cashRegisterId,
+      Number(body.openingAmount || 0),
+      req.user,
+    );
   }
 
   @Post('closure-x')
+  @Permissions('canCloseCash')
   closureX(@Body() body: any, @Req() req: any) {
     return this.sessions.closureX(body.sessionId, req.user, body.notes);
   }
 
   @Post('close')
+  @Permissions('canCloseCash')
   close(@Body() body: any, @Req() req: any) {
-    return this.sessions.close(body.sessionId, Number(body.closingAmount || 0), req.user);
+    return this.sessions.close(
+      body.sessionId,
+      Number(body.closingAmount || 0),
+      req.user,
+    );
   }
 
   @Post('close/preview')
@@ -36,6 +58,7 @@ export class CashRegisterController {
   }
 
   @Post('movement')
+  @Permissions('canCashMovement')
   movement(@Body() body: any, @Req() req: any) {
     return this.movements.create({
       cashSessionId: body.sessionId,

--- a/apps/api/src/cash-register/cash-register.module.ts
+++ b/apps/api/src/cash-register/cash-register.module.ts
@@ -4,9 +4,16 @@ import { CashSessionsService } from '../cash-sessions/cash-sessions.service';
 import { CashMovementsService } from '../cash-movements/cash-movements.service';
 import { PrismaService } from '../prisma.service';
 import { AuditService } from '../audit/audit.service';
+import { PermissionsGuard } from '../auth/permissions.guard';
 
 @Module({
   controllers: [CashRegisterController],
-  providers: [CashSessionsService, CashMovementsService, PrismaService, AuditService],
+  providers: [
+    CashSessionsService,
+    CashMovementsService,
+    PrismaService,
+    AuditService,
+    PermissionsGuard,
+  ],
 })
 export class CashRegisterModule {}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -215,10 +215,48 @@ model SaleItem {
 }
 
 model User {
-  id       Int    @id @default(autoincrement())
-  email    String @unique
+  id       String   @id @default(cuid())
+  email    String   @unique
   name     String?
   password String?
+  roles    UserRole[]
+}
+
+model Permission {
+  id          String   @id @default(cuid())
+  name        String   @unique
+  description String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  roles       RolePermission[]
+}
+
+model Role {
+  id          String   @id @default(cuid())
+  name        String   @unique
+  description String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  permissions RolePermission[]
+  users       UserRole[]
+}
+
+model RolePermission {
+  id           String @id @default(cuid())
+  roleId       String
+  permissionId String
+  role         Role       @relation(fields: [roleId], references: [id])
+  permission   Permission @relation(fields: [permissionId], references: [id])
+  @@unique([roleId, permissionId])
+}
+
+model UserRole {
+  id     String @id @default(cuid())
+  userId String
+  roleId String
+  user   User @relation(fields: [userId], references: [id])
+  role   Role @relation(fields: [roleId], references: [id])
+  @@unique([userId, roleId])
 }
 
 enum SaleType {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,76 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const PERMISSIONS = [
+  'canOpenCash',
+  'canCloseCash',
+  'canCashMovement',
+  'canViewSalesSummary',
+  'canIssueInvoice',
+  'canRetryAfip',
+  'canManagePayments',
+  'canReconcilePayments',
+  'canImportProducts',
+  'canEditPrices',
+  'canEditCost',
+  'canViewKpis',
+  'canCreatePO',
+  'canReceivePO',
+  'canApproveInventory',
+  'canCountStock',
+  'canExportReports',
+  'canManageUsers',
+  'canManageRoles',
+];
+
+const ROLES: Record<string, string[]> = {
+  ADMIN: PERMISSIONS,
+  VENDEDOR: [
+    'canOpenCash',
+    'canCloseCash',
+    'canCashMovement',
+    'canIssueInvoice',
+    'canViewSalesSummary',
+  ],
+  STOCK: ['canCountStock', 'canApproveInventory', 'canImportProducts'],
+  COMPRAS: ['canCreatePO', 'canReceivePO', 'canImportProducts', 'canEditCost'],
+  CONTABILIDAD: ['canReconcilePayments', 'canExportReports', 'canViewKpis'],
+};
+
+async function main() {
+  for (const name of PERMISSIONS) {
+    await prisma.permission.upsert({
+      where: { name },
+      update: {},
+      create: { name },
+    });
+  }
+
+  for (const [roleName, perms] of Object.entries(ROLES)) {
+    const role = await prisma.role.upsert({
+      where: { name: roleName },
+      update: {},
+      create: { name: roleName },
+    });
+    const permissionRecords = await prisma.permission.findMany({
+      where: { name: { in: perms } },
+    });
+    for (const perm of permissionRecords) {
+      await prisma.rolePermission.upsert({
+        where: { roleId_permissionId: { roleId: role.id, permissionId: perm.id } },
+        update: {},
+        create: { roleId: role.id, permissionId: perm.id },
+      });
+    }
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- define Permission, Role and linking models in Prisma schema
- seed baseline roles and permissions
- add Permissions decorator and guard with caching
- protect cash register actions with permission checks

## Testing
- ⚠️ `npx prisma generate` *(npm error 403 Forbidden)*
- ⚠️ `npm --prefix apps/api test` *(jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ca3d40b0483318d7d1427064ddce4