### PR TITLE
feat(audit): expand audit logging

### DIFF
--- a/apps/api/src/audit/audit.service.ts
+++ b/apps/api/src/audit/audit.service.ts
@@ -7,7 +7,7 @@ export class AuditService {
   constructor(private prisma: PrismaService) {}
 
   async log(dto: CreateAuditLogDto) {
-    return this.prisma.auditLog.create({ data: dto });
+    return this.prisma.auditLog.create({ data: dto as any });
   }
 
   findAll(filters: {
@@ -22,13 +22,13 @@ export class AuditService {
     if (filters.actionType) where.actionType = filters.actionType as any;
     if (filters.entity) where.entity = filters.entity;
     if (filters.from || filters.to) {
-      where.timestamp = {};
-      if (filters.from) where.timestamp.gte = filters.from;
-      if (filters.to) where.timestamp.lte = filters.to;
+      where.ts = {};
+      if (filters.from) where.ts.gte = filters.from;
+      if (filters.to) where.ts.lte = filters.to;
     }
     return this.prisma.auditLog.findMany({
       where,
-      orderBy: { timestamp: 'desc' },
+      orderBy: { ts: 'desc' } as any,
     });
   }
 }

--- a/apps/api/src/audit/dto/create-audit-log.dto.ts
+++ b/apps/api/src/audit/dto/create-audit-log.dto.ts
@@ -1,10 +1,43 @@
 import { AuditActionType } from '@prisma/client';
 
+export enum AuditAction {
+  LOGIN = 'LOGIN',
+  LOGOUT = 'LOGOUT',
+  CREATE = 'CREATE',
+  UPDATE = 'UPDATE',
+  DELETE = 'DELETE',
+  APPROVE = 'APPROVE',
+  REJECT = 'REJECT',
+  EXPORT = 'EXPORT',
+  CASH_OPEN = 'CASH_OPEN',
+  CASH_CLOSE = 'CASH_CLOSE',
+  INVENTORY_START = 'INVENTORY_START',
+  INVENTORY_FINISH = 'INVENTORY_FINISH',
+  INVENTORY_APPROVE = 'INVENTORY_APPROVE',
+  PAYMENT_CREATE = 'PAYMENT_CREATE',
+  PAYMENT_APPROVE = 'PAYMENT_APPROVE',
+  PAYMENT_REFUND = 'PAYMENT_REFUND',
+  AFIP_ENQUEUE = 'AFIP_ENQUEUE',
+  AFIP_EMIT_SUCCESS = 'AFIP_EMIT_SUCCESS',
+  AFIP_EMIT_ERROR = 'AFIP_EMIT_ERROR',
+}
+
 export class CreateAuditLogDto {
-  userId: string;
-  userEmail: string;
-  actionType: AuditActionType;
-  entity: string;
+  userId?: string;
+  userEmail?: string;
+  actionType?: AuditActionType;
+  action?: AuditAction;
+  entity?: string;
   entityId?: string;
+  route?: string;
+  method?: string;
+  statusCode?: number;
+  ip?: string;
+  userAgent?: string;
   details?: string;
+  before?: any;
+  after?: any;
+  diff?: any;
+  meta?: any;
+  ts?: Date;
 }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,8 +1,42 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { AuditService } from './audit/audit.service';
+import { AuditAction } from './audit/dto/create-audit-log.dto';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  const audit = app.get(AuditService);
+  app.use((req, res, next) => {
+    const start = Date.now();
+    res.on('finish', () => {
+      const actionMap: Record<string, AuditAction> = {
+        POST: AuditAction.CREATE,
+        PUT: AuditAction.UPDATE,
+        PATCH: AuditAction.UPDATE,
+        DELETE: AuditAction.DELETE,
+      };
+      const action = actionMap[req.method];
+      if (!action) return;
+      const duration = Date.now() - start;
+      const user: any = (req as any).user || {};
+      audit
+        .log({
+          userId: user.id,
+          userEmail: user.email,
+          action,
+          route: req.originalUrl,
+          method: req.method,
+          statusCode: res.statusCode,
+          ip: (req.headers['x-forwarded-for'] as string) || req.ip,
+          userAgent: req.headers['user-agent'] as string,
+          meta: { durationMs: duration },
+        })
+        .catch(() => undefined);
+    });
+    next();
+  });
+
   app.setGlobalPrefix('api');
   await app.listen(process.env.PORT || 3000);
 }

--- a/apps/web/app/audit-logs/page.tsx
+++ b/apps/web/app/audit-logs/page.tsx
@@ -26,7 +26,7 @@ export default async function AuditLogsPage() {
         <tbody>
           {logs.map((log: any) => (
             <tr key={log.id} className="border-t">
-              <td className="px-2 py-1">{new Date(log.timestamp).toLocaleString()}</td>
+              <td className="px-2 py-1">{new Date(log.ts).toLocaleString()}</td>
               <td className="px-2 py-1">{log.userEmail}</td>
               <td className="px-2 py-1">{log.action}</td>
               <td className="px-2 py-1">{log.entity}</td>

--- a/apps/web/app/auditoria/page.tsx
+++ b/apps/web/app/auditoria/page.tsx
@@ -49,7 +49,7 @@ export default function AuditoriaPage() {
   }, []);
 
   const columns = [
-    { Header: 'Fecha', accessor: (row: any) => new Date(row.timestamp).toLocaleString() },
+    { Header: 'Fecha', accessor: (row: any) => new Date(row.ts).toLocaleString() },
     { Header: 'Usuario', accessor: 'userEmail' },
     { Header: 'Acción', accessor: 'actionType' },
     { Header: 'Entidad', accessor: 'entity' },

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -557,13 +557,28 @@ model GoodsReceiptItem {
 
 model AuditLog {
   id         String          @id @default(uuid()) @db.Uuid
-  userId     String
-  userEmail  String
-  actionType AuditActionType
-  entity     String
+  ts         DateTime        @default(now())
+  userId     String?
+  userEmail  String?
+  action     AuditAction?
+  actionType AuditActionType?
+  entity     String?
   entityId   String?
-  timestamp  DateTime        @default(now())
+  route      String?
+  method     String?
+  statusCode Int?
+  ip         String?
+  userAgent  String?
   details    String?
+  before     Json?
+  after      Json?
+  diff       Json?
+  meta       Json?
+  createdAt  DateTime        @default(now())
+
+  @@index([ts])
+  @@index([entity, entityId])
+  @@index([action])
 }
 
 enum AuditActionType {
@@ -596,6 +611,28 @@ enum AuditActionType {
   VARIANT_CONSUME_PLAN_CREATED
   VARIANT_CONSUME_COMMIT
   VARIANT_CONSUME_ROLLBACK
+}
+
+enum AuditAction {
+  LOGIN
+  LOGOUT
+  CREATE
+  UPDATE
+  DELETE
+  APPROVE
+  REJECT
+  EXPORT
+  CASH_OPEN
+  CASH_CLOSE
+  INVENTORY_START
+  INVENTORY_FINISH
+  INVENTORY_APPROVE
+  PAYMENT_CREATE
+  PAYMENT_APPROVE
+  PAYMENT_REFUND
+  AFIP_ENQUEUE
+  AFIP_EMIT_SUCCESS
+  AFIP_EMIT_ERROR
 }
 
 model Backup {


### PR DESCRIPTION
## Summary
- expand Prisma AuditLog model with request metadata, snapshot fields and AuditAction enum
- capture mutation requests globally and persist metadata through AuditService
- show updated audit timestamps in web audit pages

## Testing
- `npm run -s check` *(fails: type errors in server modules)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ca692a79883318e846d1b0731edb9