### PR TITLE
feat: add PWA and offline POS support

### DIFF
--- a/apps/api/src/idempotency/idempotency.service.ts
+++ b/apps/api/src/idempotency/idempotency.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import * as crypto from 'crypto';
+
+@Injectable()
+export class IdempotencyService {
+  constructor(private prisma: PrismaService) {}
+
+  private hash(body: any) {
+    return crypto.createHash('sha256').update(JSON.stringify(body)).digest('hex');
+  }
+
+  async get(key: string, endpoint: string, body: any) {
+    const record = await this.prisma.idempotencyKey.findUnique({ where: { key } });
+    if (record && record.endpoint === endpoint && record.bodyHash === this.hash(body)) {
+      return record.response as any;
+    }
+    return null;
+  }
+
+  async save(key: string, endpoint: string, body: any, response: any) {
+    await this.prisma.idempotencyKey.create({
+      data: {
+        key,
+        endpoint,
+        bodyHash: this.hash(body),
+        response,
+      },
+    });
+  }
+}

--- a/apps/api/src/sales/sales.controller.ts
+++ b/apps/api/src/sales/sales.controller.ts
@@ -9,10 +9,15 @@ export class SalesController {
 
   @Post()
   create(@Body() body: CreateSaleDto, @Req() req: any) {
-    return this.salesService.create(body, {
-      id: req.user?.id,
-      email: req.user?.email,
-    });
+    const key = req.headers['x-idempotency-key'] as string | undefined;
+    return this.salesService.create(
+      body,
+      {
+        id: req.user?.id,
+        email: req.user?.email,
+      },
+      key,
+    );
   }
 
   @Get()

--- a/apps/api/src/sales/sales.module.ts
+++ b/apps/api/src/sales/sales.module.ts
@@ -5,10 +5,11 @@ import { PromotionsModule } from '../promotions/promotions.module';
 import { PrismaService } from '../prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { PaymentsModule } from '../payments/payments.module';
+import { IdempotencyService } from '../idempotency/idempotency.service';
 
 @Module({
   imports: [PromotionsModule, PaymentsModule],
   controllers: [SalesController],
-  providers: [SalesService, PrismaService, AuditService],
+  providers: [SalesService, PrismaService, AuditService, IdempotencyService],
 })
 export class SalesModule {}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -5,11 +5,15 @@ import { ErrorBoundary } from '@sentry/nextjs';
 
 export const metadata = {
   icons: { icon: '/logo.png' },
+  manifest: '/manifest.webmanifest',
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
+      <head>
+        <link rel="manifest" href="/manifest.webmanifest" />
+      </head>
       <body>
         <ErrorBoundary fallback={<p>Something went wrong</p>}>
           <Providers>{children}</Providers>

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -1,14 +1,59 @@
 'use client';
 import { SessionProvider } from 'next-auth/react';
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { CartProvider } from './cart-context';
 import { Toaster } from 'react-hot-toast';
+import { syncPendingSales, pendingSalesCount } from '../lib/offline-sales';
 
 export default function Providers({ children }: { children: ReactNode }) {
+  const [installPrompt, setInstallPrompt] = useState<any>(null);
+  const [pending, setPending] = useState(0);
+
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/sw.js');
+    }
+    const handler = (e: any) => {
+      e.preventDefault();
+      setInstallPrompt(e);
+    };
+    window.addEventListener('beforeinstallprompt', handler);
+    const interval = setInterval(() => {
+      if (navigator.onLine) {
+        syncPendingSales();
+      }
+      pendingSalesCount().then(setPending);
+    }, 10000);
+    pendingSalesCount().then(setPending);
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handler);
+      clearInterval(interval);
+    };
+  }, []);
+
+  const install = async () => {
+    await installPrompt.prompt();
+    await installPrompt.userChoice;
+    setInstallPrompt(null);
+  };
+
   return (
     <SessionProvider>
       <CartProvider>
         {children}
+        {pending > 0 && !navigator.onLine && (
+          <div className="fixed top-0 inset-x-0 bg-yellow-500 text-black text-center p-2">
+            Modo offline: {pending} ventas en cola
+          </div>
+        )}
+        {installPrompt && (
+          <button
+            onClick={install}
+            className="fixed bottom-4 right-4 bg-blue-600 text-white px-4 py-2 rounded"
+          >
+            Instalar app
+          </button>
+        )}
         <Toaster position="top-right" />
       </CartProvider>
     </SessionProvider>

--- a/apps/web/hooks/useCatalog.ts
+++ b/apps/web/hooks/useCatalog.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { db, Product } from '../lib/db';
+
+export function useCatalog() {
+  const [products, setProducts] = useState<Product[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      const cached = await db.products.toArray();
+      if (cached.length) {
+        setProducts(cached);
+      }
+      try {
+        const { data } = await axios.get('/api/public/products');
+        await db.products.clear();
+        await db.products.bulkPut(data);
+        setProducts(data);
+        localStorage.setItem('lastSyncAt', new Date().toISOString());
+      } catch (e) {
+        // offline fallback
+      }
+    }
+    load();
+  }, []);
+
+  return products;
+}

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -1,0 +1,39 @@
+import Dexie, { Table } from 'dexie';
+
+export interface Product {
+  id: number;
+  name: string;
+  priceARS: number;
+  barcodes: string[];
+  contentKg?: number;
+  isBulk: boolean;
+}
+
+export interface Promotion {
+  id: number;
+  name: string;
+  discount: number;
+}
+
+export interface PendingSale {
+  clientTempId: string;
+  createdAt: number;
+  payload: any;
+}
+
+class AppDB extends Dexie {
+  products!: Table<Product, number>;
+  promotions!: Table<Promotion, number>;
+  pendingSales!: Table<PendingSale, string>;
+
+  constructor() {
+    super('pp-db');
+    this.version(1).stores({
+      products: 'id,name',
+      promotions: 'id',
+      pendingSales: 'clientTempId,createdAt'
+    });
+  }
+}
+
+export const db = new AppDB();

--- a/apps/web/lib/offline-sales.ts
+++ b/apps/web/lib/offline-sales.ts
@@ -1,0 +1,38 @@
+import { db, PendingSale } from './db';
+
+async function hash(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+export async function queueSale(payload: any) {
+  const clientTempId = crypto.randomUUID();
+  const createdAt = Date.now();
+  await db.pendingSales.put({ clientTempId, createdAt, payload });
+  return { clientTempId, createdAt };
+}
+
+export async function syncPendingSales() {
+  const sale = await db.pendingSales.orderBy('createdAt').first();
+  if (!sale) return;
+  try {
+    const key = await hash(sale.clientTempId + sale.createdAt);
+    await fetch('/api/sales', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Idempotency-Key': key,
+      },
+      body: JSON.stringify(sale.payload),
+    });
+    await db.pendingSales.delete(sale.clientTempId);
+  } catch (e) {
+    // ignore and retry later
+  }
+}
+
+export function pendingSalesCount() {
+  return db.pendingSales.count();
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,7 +24,8 @@
     "@zxing/browser": "^0.1.0",
     "qrcode.react": "^3.1.0",
     "react-hot-toast": "^2.4.1",
-    "recharts": "^2.8.0"
+    "recharts": "^2.8.0",
+    "dexie": "^3.2.4"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",

--- a/apps/web/public/icon-192.png
+++ b/apps/web/public/icon-192.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6653fd9ae97f489db5455043e5d5db867eab1ac731b26072bd9e3cae4049cb14
+size 670930

--- a/apps/web/public/icon-512.png
+++ b/apps/web/public/icon-512.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6653fd9ae97f489db5455043e5d5db867eab1ac731b26072bd9e3cae4049cb14
+size 670930

--- a/apps/web/public/manifest.webmanifest
+++ b/apps/web/public/manifest.webmanifest
@@ -1,0 +1,12 @@
+{
+  "name": "Punto Pastelero",
+  "short_name": "Punto",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png" }
+  ]
+}

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,0 +1,67 @@
+const STATIC_CACHE = 'static-v1';
+const PRODUCTS_CACHE = 'products-v1';
+const IMAGES_CACHE = 'images-v1';
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(STATIC_CACHE).then(cache =>
+      cache.addAll([
+        '/',
+        '/logo.png',
+        '/manifest.webmanifest',
+        '/icon-192.png',
+        '/icon-512.png'
+      ])
+    )
+  );
+});
+
+self.addEventListener('activate', event => {
+  const allowed = [STATIC_CACHE, PRODUCTS_CACHE, IMAGES_CACHE];
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.map(key => !allowed.includes(key) && caches.delete(key)))
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  const url = new URL(event.request.url);
+
+  if (url.pathname.startsWith('/api/public/products')) {
+    event.respondWith(staleWhileRevalidate(event.request, PRODUCTS_CACHE));
+    return;
+  }
+
+  if (url.pathname.match(/\/uploads\/.*\.(png|jpg|jpeg|gif|webp)$/)) {
+    event.respondWith(cacheFirst(event.request, IMAGES_CACHE, 50));
+    return;
+  }
+});
+
+function staleWhileRevalidate(request, cacheName) {
+  return caches.open(cacheName).then(async cache => {
+    const cached = await cache.match(request);
+    const network = fetch(request)
+      .then(response => {
+        cache.put(request, response.clone());
+        return response;
+      })
+      .catch(() => cached);
+    return cached || network;
+  });
+}
+
+function cacheFirst(request, cacheName, maxItems) {
+  return caches.open(cacheName).then(async cache => {
+    const cached = await cache.match(request);
+    if (cached) return cached;
+    const response = await fetch(request);
+    cache.put(request, response.clone());
+    const keys = await cache.keys();
+    if (keys.length > maxItems) {
+      cache.delete(keys[0]);
+    }
+    return response;
+  });
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1081,3 +1081,12 @@ model InventoryAdjustment {
   updatedAt     DateTime @updatedAt
 }
 
+model IdempotencyKey {
+  key       String   @id
+  endpoint  String
+  bodyHash  String
+  response  Json
+  createdAt DateTime @default(now())
+  ttl       Int?
+}
+


### PR DESCRIPTION
## Summary
- add web manifest and service worker for basic caching
- queue POS sales offline and retry when back online
- implement backend idempotency records for `X-Idempotency-Key`

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` (apps/api) *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ddafbee688331b623f33458e86594