### PR TITLE
docs: add onboarding and backup tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,44 @@
+# Base configuration
+NODE_ENV=development # required
+TZ=America/Argentina/Buenos_Aires # optional
+
+# Database
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/puntopastelero?schema=public" # required
+
+# API
+API_PORT=3001 # optional
+API_LOG_LEVEL=info # optional
+CORS_ORIGINS=http://localhost:3000 # optional
+RATE_LIMIT_WINDOW_MS=60000 # optional
+RATE_LIMIT_MAX=200 # optional
+METRICS_TOKEN= # optional
+
+# Web / NextAuth
+NEXTAUTH_URL=http://localhost:3000 # required
+NEXTAUTH_SECRET=changeme # required
+
+# AFIP
+AFIP_MODE=test # required
+AFIP_CUIT=20XXXXXXXXX # required
+AFIP_CERT_BASE64= # required
+AFIP_KEY_BASE64= # required
+AFIP_POINT_OF_SALE=3 # optional
+
+# Mercado Pago
+MP_ACCESS_TOKEN= # optional
+MP_WEBHOOK_SECRET= # optional
+MP_SUCCESS_URL=http://localhost:3000/pago/success # required
+MP_FAILURE_URL=http://localhost:3000/pago/failure # required
+
+# Getnet
+GETNET_CLIENT_ID= # optional
+GETNET_CLIENT_SECRET= # optional
+GETNET_BASE_URL=https://api.getnet.com.ar # optional
+GETNET_WEBHOOK_SECRET= # optional
+
+# Sentry
+SENTRY_DSN= # optional
+
+# Frontend URLs
+FRONTEND_BASE_URL=http://localhost:3000 # optional
+ADMIN_BASE_URL=http://localhost:3000 # optional

--- a/README.md
+++ b/README.md
@@ -1,27 +1,46 @@
-# Sistema POS
+# Punto Pastelero
 
-This project contains a point-of-sale application with a React frontend and an Express backend.
+Monorepo que contiene la API (NestJS) y el frontend (Next.js) de un sistema de punto de venta. Usa Prisma para acceso a datos y Postgres como base de datos. Los servicios se empaquetan con Docker.
 
-## Environment variables
+## Requisitos previos
+- Node.js 18 o 20
+- Docker y Docker Compose
+- Git
 
-The server requires a `SESSION_SECRET` environment variable for managing user sessions. The
-application will throw an error during startup if this variable is not defined.
+## Estructura
+- `apps/api`: API en NestJS
+- `apps/web`: Frontend en Next.js
+- `prisma`: esquema y migraciones
+- `scripts/`: utilidades varias
 
-## Development
-
-Install dependencies and start the application in development mode:
-
+## Setup rápido (dev)
 ```bash
-npm install
-npm run dev
+cp .env.example .env
+cd apps/api && npm ci && cd ..
+cd apps/web && npm ci && cd ..
+docker compose up -d db
+npx prisma generate
+npx prisma migrate dev
+npm run dev --workspace apps/api &
+npm run dev --workspace apps/web
 ```
 
-The server listens on port `5000` by default.
+## Scripts útiles
+- `npm run build` – compilar aplicaciones
+- `npm test` – ejecutar pruebas
+- `npm run seed` – cargar datos de ejemplo
+- `npm run reset` – limpiar base de datos
+- `npm run backup:db` – generar backup
+- `npm run restore:db` – restaurar backup
+- `npm run verify:backup` – verificar integridad
 
-### Products API
+## Documentación
+- [Variables de entorno](docs/env.md)
+- [Operaciones](docs/ops.md)
+- [Plan de recuperación ante desastres](docs/drp.md)
 
-`GET /api/products` now accepts optional query parameters:
-
-- `search`: filter products by name or description (case insensitive).
-- `sort`: order results by `name` or `price`.
-
+## Troubleshooting
+- **Puertos ocupados:** detener procesos en `3000`, `3001` o `5432`.
+- **Prisma 403:** validar conexión y credenciales de la base.
+- **PDF/Excel en serverless:** usar funciones `edge` o servidor dedicado.
+- **Git LFS:** instalar [Git LFS](https://git-lfs.github.com/) y ejecutar `git lfs install`.

--- a/docs/drp.md
+++ b/docs/drp.md
@@ -1,0 +1,51 @@
+# Plan de Recuperación ante Desastres (DRP)
+
+## Objetivos
+- **RTO sugerido:** ≤ 2 horas.
+- **RPO sugerido:** ≤ 1 hora.
+
+## Activos a respaldar
+- Base de datos **Postgres**.
+- Carpeta `exports/` con reportes generados.
+- Imágenes o archivos estáticos subidos (Cloudinary u otro storage externo).
+
+## Frecuencia y retención
+- Backups diarios: conservar 30 días.
+- Backups semanales: conservar 12 semanas.
+- Backups mensuales: conservar 12 meses.
+
+## Procedimiento de backup
+1. Ejecutar `npm run backup:db`.
+2. Copiar `exports/` e imágenes a almacenamiento seguro.
+
+## Procedimiento de restauración
+1. Detener servicios afectados.
+2. Restaurar base de datos: `npm run restore:db <backup>`.
+3. Restaurar carpeta `exports/` e imágenes si corresponde.
+4. Levantar servicios: `docker compose up -d`.
+5. Verificar integridad: `npm run verify:backup <backup>`.
+6. Probar endpoints críticos: `/health`, venta simple, export PDF/Excel.
+
+## Pruebas
+- Realizar prueba de restore **trimestral** en entorno de staging.
+- Registrar tiempos de restauración para validar el RTO.
+
+## Playbook: Servidor caído
+1. Confirmar incidente y notificar al equipo.
+2. Restaurar DB desde último backup verificado.
+3. Recuperar `exports/` e imágenes si aplica.
+4. Levantar servicios con `docker compose up -d`.
+5. Ejecutar `npm run verify:backup`.
+6. Validar endpoints críticos.
+7. Comunicar estado a stakeholders.
+
+## Contactos y escalamiento
+- Responsable de infraestructura.
+- Responsable de desarrollo.
+- Contacto de soporte del proveedor de hosting.
+
+## Checklist post-incidente
+- [ ] Causa raíz identificada.
+- [ ] Acciones correctivas definidas.
+- [ ] Backups verificados.
+- [ ] Documentación actualizada.

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,0 +1,51 @@
+# Variables de entorno
+
+Este archivo describe todas las variables utilizadas por Punto Pastelero.
+
+## Variables
+
+| Variable | Descripción | Ejemplo | Obligatoria |
+|----------|-------------|---------|-------------|
+| `NODE_ENV` | Modo de ejecución (`development`, `production`) | `development` | Sí |
+| `TZ` | Zona horaria | `America/Argentina/Buenos_Aires` | No |
+| `DATABASE_URL` | Cadena de conexión a Postgres | `postgresql://postgres:postgres@localhost:5432/puntopastelero?schema=public` | Sí |
+| `API_PORT` | Puerto de la API | `3001` | No |
+| `API_LOG_LEVEL` | Nivel de log para pino | `info` | No |
+| `CORS_ORIGINS` | Orígenes permitidos para CORS | `http://localhost:3000` | No |
+| `RATE_LIMIT_WINDOW_MS` | Ventana de rate limit en ms | `60000` | No |
+| `RATE_LIMIT_MAX` | Cantidad máxima de requests por ventana | `200` | No |
+| `METRICS_TOKEN` | Token para proteger `/metrics` | `secreta` | No |
+| `NEXTAUTH_URL` | URL base del frontend para NextAuth | `http://localhost:3000` | Sí |
+| `NEXTAUTH_SECRET` | Clave para sesiones de NextAuth | `changeme` | Sí |
+| `AFIP_MODE` | Modo de AFIP (`test` o `prod`) | `test` | Sí |
+| `AFIP_CUIT` | CUIT del contribuyente | `20XXXXXXXXX` | Sí |
+| `AFIP_CERT_BASE64` | Certificado en base64 | `...` | Sí |
+| `AFIP_KEY_BASE64` | Llave privada en base64 | `...` | Sí |
+| `AFIP_POINT_OF_SALE` | Punto de venta | `3` | No |
+| `MP_ACCESS_TOKEN` | Token de Mercado Pago | `app_...` | No |
+| `MP_WEBHOOK_SECRET` | Secreto para webhooks de Mercado Pago | `...` | No |
+| `MP_SUCCESS_URL` | URL de éxito | `http://localhost:3000/pago/success` | Sí |
+| `MP_FAILURE_URL` | URL de falla | `http://localhost:3000/pago/failure` | Sí |
+| `GETNET_CLIENT_ID` | Cliente de Getnet | `...` | No |
+| `GETNET_CLIENT_SECRET` | Secreto de Getnet | `...` | No |
+| `GETNET_BASE_URL` | Endpoint base de Getnet | `https://api.getnet.com.ar` | No |
+| `GETNET_WEBHOOK_SECRET` | Secreto para webhooks de Getnet | `...` | No |
+| `SENTRY_DSN` | DSN de Sentry para reportes de errores | `https://...` | No |
+| `FRONTEND_BASE_URL` | URL pública del sitio | `http://localhost:3000` | No |
+| `ADMIN_BASE_URL` | URL del panel administrativo | `http://localhost:3000` | No |
+| `REDIS_URL` | URL para cache Redis (si aplica) | `redis://localhost:6379` | No |
+
+## Configuración por ambiente
+
+| Variable | Local | Staging | Producción |
+|----------|-------|---------|------------|
+| `NODE_ENV` | `development` | `production` | `production` |
+| `DATABASE_URL` | `postgresql://postgres:postgres@localhost:5432/puntopastelero` | provista por el entorno | provista por el entorno |
+| `NEXTAUTH_URL` | `http://localhost:3000` | `https://staging.puntopastelero.com` | `https://puntopastelero.com` |
+| `AFIP_MODE` | `test` | `prod` | `prod` |
+| `MP_SUCCESS_URL` | `http://localhost:3000/pago/success` | `https://staging.puntopastelero.com/pago/success` | `https://puntopastelero.com/pago/success` |
+| `MP_FAILURE_URL` | `http://localhost:3000/pago/failure` | `https://staging.puntopastelero.com/pago/failure` | `https://puntopastelero.com/pago/failure` |
+| `SENTRY_DSN` | vacío | DSN de staging | DSN de producción |
+| `REDIS_URL` | `redis://localhost:6379` | URL de Redis de staging | URL de Redis prod |
+
+> Las variables no listadas en la tabla anterior usan los mismos valores entre ambientes o se documentan en el servicio correspondiente.

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -1,0 +1,50 @@
+# Operaciones
+
+Guía operativa para administrar el sistema Punto Pastelero.
+
+## Logs
+- Los servicios usan [pino](https://github.com/pinojs/pino) en formato JSON.
+- Para una visualización legible: `node archivo.log | npx pino-pretty`.
+- Niveles disponibles: `fatal`, `error`, `warn`, `info`, `debug`, `trace`.
+- Cada request incluye `request-id` para correlación.
+
+## Endpoints de salud y métricas
+- `GET /health`: verifica memoria y uptime del servicio.
+- `GET /ready`: valida conexión a la base de datos.
+- `GET /metrics`: expone métricas Prometheus (protegido con `METRICS_TOKEN`).
+
+## Reinicio de servicios
+- Con Docker: `docker compose restart api web` o `docker compose up -d`.
+- Sin Docker: reiniciar con `npm run dev` o `npm run start` según el servicio.
+
+## Exportación de reportes
+- Reportes PDF: `/api/reports/:id/pdf`.
+- Reportes Excel: `/api/reports/:id/xlsx`.
+- Los archivos se guardan en `exports/`.
+
+## Conciliación de pagos
+1. **Carga**: importar movimientos desde el proveedor (AFIP, Mercado Pago, Getnet).
+2. **Pull**: el sistema obtiene los pagos registrados.
+3. **Match**: conciliación automática y manual de transacciones.
+4. **Export**: generar reporte conciliado en PDF o Excel.
+
+## Cierre contable mensual
+1. Ejecutar cierre: `POST /api/accounting/close`.
+2. Para reabrir: `POST /api/accounting/reopen`.
+3. Exportar reportes: `GET /api/accounting/export`.
+
+## Inventarios
+1. Iniciar inventario: `POST /api/inventory/start`.
+2. Escanear productos: `POST /api/inventory/scan`.
+3. Aprobar conteo: `POST /api/inventory/approve`.
+4. Ajustar stock: `POST /api/inventory/adjust`.
+
+## Backups
+- Generar backup: `npm run backup:db`.
+- Los archivos se guardan en `backups/` con fecha.
+- Verificar integridad: `npm run verify:backup backups/AAAA-MM-DD_hhmm`.
+
+## Restore
+- Restaurar: `npm run restore:db backups/AAAA-MM-DD_hhmm/db.dump`
+- Utiliza `pg_restore --clean --if-exists --no-owner`.
+- Confirmar migraciones con Prisma si aplica.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",
-    "perf:explain": "bash scripts/run-explain.sh"
+    "perf:explain": "bash scripts/run-explain.sh",
+    "backup:db": "bash scripts/backup/backup.sh",
+    "restore:db": "bash scripts/backup/restore.sh",
+    "verify:backup": "bash scripts/backup/verify.sh"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/scripts/backup/README.md
+++ b/scripts/backup/README.md
@@ -1,0 +1,27 @@
+# Scripts de backup
+
+Herramientas simples para respaldar y restaurar la base de datos.
+
+## Uso
+
+### Generar backup
+```bash
+./backup.sh
+```
+Lee `PGHOST`, `PGUSER`, `PGPASSWORD` y `PGDB` del entorno. El backup se guarda en `backups/AAAA-MM-DD_hhmm/` e incluye `META.json` y `SHA256SUMS`.
+
+### Restaurar
+```bash
+./restore.sh backups/2025-08-14_0100/db.dump
+```
+Crea la base si no existe y aplica el dump.
+
+### Verificar
+```bash
+./verify.sh backups/2025-08-14_0100/
+```
+Revisa checksum y que `pg_restore --list` sea válido.
+
+## Notas para Windows
+- Ejecutar los scripts con **Git Bash** o **WSL**.
+- Opcionalmente se pueden crear versiones PowerShell (`backup.ps1` y `restore.ps1`).

--- a/scripts/backup/backup.sh
+++ b/scripts/backup/backup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PGHOST=${PGHOST:-localhost}
+PGUSER=${PGUSER:-postgres}
+PGPASSWORD=${PGPASSWORD:-postgres}
+PGDB=${PGDB:-puntopastelero}
+RETENTION_DAYS=${RETENTION_DAYS:-}
+
+export PGHOST PGUSER PGPASSWORD
+
+TIMESTAMP=$(date +%F_%H%M)
+DEST_DIR="backups/${TIMESTAMP}"
+mkdir -p "$DEST_DIR"
+
+DUMP_FILE="$DEST_DIR/db.dump"
+pg_dump -Fc "$PGDB" > "$DUMP_FILE"
+
+if command -v tar >/dev/null 2>&1; then
+  tar -czf "$DUMP_FILE.tar.gz" -C "$DEST_DIR" db.dump
+  rm "$DUMP_FILE"
+  DUMP_FILE="$DUMP_FILE.tar.gz"
+fi
+
+SHA256=$(sha256sum "$DUMP_FILE" | awk '{print $1}')
+echo "$SHA256  $(basename "$DUMP_FILE")" > "$DEST_DIR/SHA256SUMS"
+
+SCHEMA_HASH=$(npx prisma migrate diff --from-empty --to-schema-datamodel prisma/schema.prisma 2>/dev/null | sha256sum | cut -c1-8 || echo "unknown")
+PG_VERSION=$(psql -At -c 'select version()' 2>/dev/null || echo "unknown")
+SIZE=$(stat -c%s "$DUMP_FILE" 2>/dev/null || wc -c < "$DUMP_FILE")
+
+cat > "$DEST_DIR/META.json" <<JSON
+{
+  "date": "$(date --iso-8601=seconds)",
+  "schemaHash": "$SCHEMA_HASH",
+  "size": $SIZE,
+  "pgHost": "$PGHOST",
+  "pgVersion": "$PG_VERSION"
+}
+JSON
+
+if [ -n "$RETENTION_DAYS" ]; then
+  find backups -maxdepth 1 -type d -mtime +$RETENTION_DAYS -exec rm -rf {} \; 2>/dev/null || true
+fi
+
+echo "Backup creado en $DEST_DIR"

--- a/scripts/backup/restore.sh
+++ b/scripts/backup/restore.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BACKUP_PATH="${1:-}"
+if [ -z "$BACKUP_PATH" ]; then
+  echo "Uso: $0 <ruta backup>" >&2
+  exit 1
+fi
+
+PGHOST=${PGHOST:-localhost}
+PGUSER=${PGUSER:-postgres}
+PGPASSWORD=${PGPASSWORD:-postgres}
+PGDB=${PGDB:-puntopastelero}
+
+export PGHOST PGUSER PGPASSWORD
+
+if [ -d "$BACKUP_PATH" ]; then
+  if [ -f "$BACKUP_PATH/db.dump.tar.gz" ]; then
+    BACKUP_PATH="$BACKUP_PATH/db.dump.tar.gz"
+  else
+    BACKUP_PATH="$BACKUP_PATH/db.dump"
+  fi
+fi
+
+TMPDIR=$(mktemp -d)
+if [[ "$BACKUP_PATH" == *.tar.gz ]]; then
+  tar -xzf "$BACKUP_PATH" -C "$TMPDIR"
+  DUMP_FILE="$TMPDIR/db.dump"
+else
+  DUMP_FILE="$BACKUP_PATH"
+fi
+
+psql -v ON_ERROR_STOP=1 -tc "SELECT 1 FROM pg_database WHERE datname = '$PGDB'" | grep -q 1 || psql -v ON_ERROR_STOP=1 -c "CREATE DATABASE $PGDB"
+pg_restore --clean --if-exists --no-owner -d "$PGDB" "$DUMP_FILE"
+
+LAST_MIGRATION=$(ls prisma/migrations 2>/dev/null | tail -1 || true)
+if [ -n "$LAST_MIGRATION" ]; then
+  npx prisma migrate resolve --applied "$LAST_MIGRATION" >/dev/null 2>&1 || true
+fi
+
+rm -rf "$TMPDIR"
+
+echo "Restore OK para $PGDB en $PGHOST"
+psql -d "$PGDB" -c 'select version();'

--- a/scripts/backup/verify.sh
+++ b/scripts/backup/verify.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET="${1:-}"
+if [ -z "$TARGET" ]; then
+  echo "Uso: $0 <ruta backup>" >&2
+  exit 1
+fi
+
+if [ -d "$TARGET" ]; then
+  if [ -f "$TARGET/db.dump.tar.gz" ]; then
+    DUMP_FILE="$TARGET/db.dump.tar.gz"
+  else
+    DUMP_FILE="$TARGET/db.dump"
+  fi
+else
+  DUMP_FILE="$TARGET"
+  TARGET=$(dirname "$TARGET")
+fi
+
+META="$TARGET/META.json"
+SUMS="$TARGET/SHA256SUMS"
+
+[ -f "$META" ] || { echo "META.json no encontrado" >&2; exit 1; }
+
+if [ -f "$SUMS" ]; then
+  sha256sum -c "$SUMS"
+fi
+
+TMPDIR=$(mktemp -d)
+if [[ "$DUMP_FILE" == *.tar.gz ]]; then
+  tar -xzf "$DUMP_FILE" -C "$TMPDIR"
+  TEST_FILE="$TMPDIR/db.dump"
+else
+  TEST_FILE="$DUMP_FILE"
+fi
+pg_restore --list "$TEST_FILE" >/dev/null
+rm -rf "$TMPDIR"
+
+echo "Backup verificado:"
+cat "$META"


### PR DESCRIPTION
## Summary
- document environment variables, operations, and disaster recovery
- add .env template and backup/restore/verify scripts
- wire backup helpers into package.json

## Testing
- `npm run backup:db` *(fails: pg_dump: command not found)*
- `npm run restore:db backups/test.db` *(fails: psql: command not found)*
- `npm run verify:backup backups/test` *(fails: META.json no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_689ddf5f0d94833187c3b92e47b24179