### PR TITLE
fix: update dependencies

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -34,7 +34,7 @@
     "date-fns": "^2.30.0",
     "cheerio": "^1.0.0-rc.12",
     "adm-zip": "^0.5.9",
-    "afipsdk/afip.js": "1.1.3",
+    "@afipsdk/afip.js": "1.1.3",
     "bwip-js": "^3.0.2",
     "xlsx": "^0.18.5",
     "fast-csv": "^4.3.6",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,7 @@
     "next": "^14.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "next-auth": "4.0.0",
+    "next-auth": "^4.24.7",
     "@sentry/nextjs": "^7.120.0",
     "axios": "^1.6.7",
     "tailwindcss": "^3.4.0",


### PR DESCRIPTION
## Summary
- update NextAuth to ^4.24.7 in web app
- namespace AFIP dependency to @afipsdk/afip.js in API app

## Testing
- `npm test --prefix apps/web` *(fails: jest not found)*
- `npm test --prefix apps/api` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1134d7f048331815541f0b649297e