### PR TITLE
fix next-auth and AFIP dependencies

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -34,7 +34,6 @@
     "date-fns": "^2.30.0",
     "cheerio": "^1.0.0-rc.12",
     "adm-zip": "^0.5.9",
-    "afip.js": "github:afipsdk/afip.js#1.1.3",
     "bwip-js": "^3.0.2",
     "xlsx": "^0.18.5",
     "fast-csv": "^4.3.6",
@@ -42,7 +41,8 @@
     "cron": "^2.4.3",
     "@nestjs/cache-manager": "^2.2.2",
     "papaparse": "^5.4.1",
-    "@nestjs/mapped-types": "^2.0.5"
+    "@nestjs/mapped-types": "^2.0.5",
+    "@afipsdk/afip.js": "github:afipsdk/afip.js#1.1.3"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,7 @@
     "next": "^14.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "next-auth": "4.0.0",
+    "next-auth": "^4.24.7",
     "@sentry/nextjs": "^7.120.0",
     "axios": "^1.6.7",
     "tailwindcss": "^3.4.0",


### PR DESCRIPTION
## Summary
- upgrade next-auth to v4.24.7 in web app
- rename afip package to @afipsdk/afip.js in API app

## Testing
- `cd apps/web && npm test` *(fails: jest not found)*
- `cd apps/api && npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a116611fbc833187a0a936457c6c83