### PR TITLE
chore(api): update test dependencies

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -42,7 +42,7 @@
     "@nestjs/cache-manager": "^2.2.2",
     "papaparse": "^5.4.1",
     "@nestjs/mapped-types": "^2.0.5",
-    "@afipsdk/afip.js": "github:afipsdk/afip.js#1.1.3"
+    "@afipsdk/afip.js": "1.1.3"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",
@@ -54,7 +54,8 @@
     "ts-jest": "^29.0.0",
     "@types/jest": "^29.0.0",
     "@nestjs/testing": "^10.0.0",
-    "supertest": "^6.3.3",
+    "superagent": "^10.2.2",
+    "supertest": "^7.1.3",
     "@types/supertest": "^2.0.12",
     "ioredis": "^5.3.2",
     "@types/express": "^4.17.21",


### PR DESCRIPTION
## Summary
- replace deprecated supertest version with ^7.1.3
- add superagent ^10.2.2 to match supertest requirements
- use published @afipsdk/afip.js package instead of GitHub reference

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ba2c41f8833190ac83150fadaa01