### PR TITLE
chore(web): bump deps to drop deprecated glob

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "next-auth": "^4.24.7",
-    "@sentry/nextjs": "^7.120.0",
+    "@sentry/nextjs": "^8.0.0",
     "axios": "^1.6.7",
     "tailwindcss": "^3.4.0",
     "@prisma/client": "^5.0.0",
@@ -35,9 +35,9 @@
     "@testing-library/react": "^14.0.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/user-event": "^14.0.0",
-    "jest": "^29.0.0",
+    "jest": "^29.7.0",
     "@types/jest": "^29.0.0",
     "@types/node": "^20.0.0",
-    "ts-jest": "^29.0.0"
+    "ts-jest": "^29.4.1"
   }
 }


### PR DESCRIPTION
## Summary
- bump `@sentry/nextjs` to v8 and update Jest stack

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm audit` *(fails: requires existing lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68a265b5ed0083318d3c8def436eee8c