### PR TITLE
fix: resolve type issues

### DIFF
--- a/apps/api/src/backups/backups.controller.ts
+++ b/apps/api/src/backups/backups.controller.ts
@@ -12,6 +12,7 @@ import { BackupsService } from './backups.service';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { Response } from 'express';
 import type { Express } from 'express';
+import 'multer';
 
 @Controller('backups')
 export class BackupsController {

--- a/apps/api/src/backups/backups.service.ts
+++ b/apps/api/src/backups/backups.service.ts
@@ -6,6 +6,7 @@ import AdmZip from 'adm-zip';
 import { AuditService } from '../audit/audit.service';
 import { AuditActionType } from '@prisma/client';
 import type { Express } from 'express';
+import 'multer';
 
 @Injectable()
 export class BackupsService {

--- a/apps/api/src/imports/imports.controller.ts
+++ b/apps/api/src/imports/imports.controller.ts
@@ -13,6 +13,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { ImportsService } from './imports.service';
 import { ImportProductDto } from './dto/import-product.dto';
 import type { Express } from 'express';
+import 'multer';
 
 @Controller()
 export class ImportsController {

--- a/apps/api/src/imports/imports.service.ts
+++ b/apps/api/src/imports/imports.service.ts
@@ -5,6 +5,7 @@ import { ImportProductDto } from './dto/import-product.dto';
 import { AuditService } from '../audit/audit.service';
 import { AuditActionType } from '@prisma/client';
 import type { Express } from 'express';
+import 'multer';
 
 @Injectable()
 export class ImportsService {

--- a/apps/api/src/invoices/invoices.service.ts
+++ b/apps/api/src/invoices/invoices.service.ts
@@ -59,13 +59,14 @@ export class InvoicesService {
     };
   }
 
-  async generateRemito(saleId: string) {
+  async generateRemito(saleId: string, ptoVta?: number) {
     const invoice = await this.prisma.invoice.upsert({
       where: { saleId },
       create: {
         sale: { connect: { id: saleId } },
         docType: AfipDocType.RC,
         pdfUrl: `/documents/remito/${saleId}/pdf`,
+        ptoVta: ptoVta ?? 0,
       },
       update: { docType: AfipDocType.RC, pdfUrl: `/documents/remito/${saleId}/pdf` },
     });

--- a/apps/api/src/kits/kits.service.ts
+++ b/apps/api/src/kits/kits.service.ts
@@ -96,7 +96,7 @@ export class KitsService {
       );
     }
     const stocks = kit.kitItems.map((ki: any) =>
-      Math.floor(ki.component.stock / Number(ki.quantity)),
+      Math.floor(Number(ki.component.stock) / Number(ki.quantity)),
     );
     kit.stock = stocks.length ? Math.min(...stocks) : 0;
     return kit;

--- a/apps/api/src/kpis/kpis.service.ts
+++ b/apps/api/src/kpis/kpis.service.ts
@@ -105,13 +105,13 @@ export class KpisService {
         quantity: true,
         price: true,
         discount: true,
-        product: { select: { name: true, costARS: true } },
+        product: { select: { id: true, name: true, costARS: true } },
       },
     });
     const map = new Map<string, { name: string; total: number }>();
     for (const item of items) {
       const key = String(item.productId ?? item.product?.id ?? 'unknown');
-      const current = map.get(key) || { name: item.product.name, total: 0 };
+      const current = map.get(key) || { name: item.product?.name ?? 'N/D', total: 0 };
       const price =
         Number(item.price) * Number(item.quantity) - Number(item.discount ?? 0);
       const value =

--- a/apps/api/src/pricing/pricing.controller.ts
+++ b/apps/api/src/pricing/pricing.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Get, Post, UploadedFile, UseInterceptors } from '@nes
 import { FileInterceptor } from '@nestjs/platform-express';
 import { PricingService } from './pricing.service';
 import type { Express } from 'express';
+import 'multer';
 
 @Controller()
 export class PricingController {

--- a/apps/api/src/pricing/pricing.service.ts
+++ b/apps/api/src/pricing/pricing.service.ts
@@ -4,6 +4,7 @@ import { PrismaService } from '../prisma.service';
 import * as ExcelJS from 'exceljs';
 import * as cheerio from 'cheerio';
 import type { Express } from 'express';
+import 'multer';
 
 interface Suggestion {
   productId: number;

--- a/apps/api/src/products/products.service.ts
+++ b/apps/api/src/products/products.service.ts
@@ -117,7 +117,7 @@ export class ProductsService {
       );
     }
     const stocks = product.kitItems.map((ki: any) =>
-      Math.floor(ki.component.stock / Number(ki.quantity)),
+      Math.floor(Number(ki.component.stock) / Number(ki.quantity)),
     );
     product.stock = stocks.length ? Math.min(...stocks) : 0;
     return product;

--- a/apps/api/src/settlements/settlements.controller.ts
+++ b/apps/api/src/settlements/settlements.controller.ts
@@ -15,6 +15,7 @@ import * as ExcelJS from 'exceljs';
 import { SettlementGateway, SettlementStatus } from '@prisma/client';
 import { FileInterceptor } from '@nestjs/platform-express';
 import type { Express } from 'express';
+import 'multer';
 
 @Controller('settlements')
 export class SettlementsController {


### PR DESCRIPTION
## Summary
- add Express/Multer imports for file upload controllers and services
- handle Prisma Decimal math with `Number()` conversions and map key typing for KPIs
- include parent product data for packaging variants and add `ptoVta` to remito creation

## Testing
- `npx prisma generate` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2836171e08331b7d9e3993cb58c46